### PR TITLE
Update ESLint setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,8 @@
         "devDependencies": [
           "**/*.test.{js,jsx}",
           "**/jest.config.js",
-          "**/jest.setup.js"
+          "**/jest.setup.js",
+          "scripts/*"
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "watch": "nodemon start.js",
     "debug": "ndb start.js",
     "console": "node --experimental-repl-await console.js",
-    "lint": "eslint .",
+    "lint": "eslint --ignore-path .gitignore . scripts/*",
     "test": "jest --runInBand"
   },
   "engines": {

--- a/scripts/gen-apidoc
+++ b/scripts/gen-apidoc
@@ -1,24 +1,24 @@
 #!/usr/bin/env node
 
-const yaml = require('js-yaml')
+const yaml = require('js-yaml');
 
-require('../config/boot')
+require('../config/boot');
 
-const environment = require('../config/environment')
-const init = require('../server')
+const environment = require('../config/environment');
+const init = require('../server');
 
 async function main() {
-  const server = await init({ ...environment, logging: false })
-  const response = await server.inject('/swagger')
+  const server = await init({ ...environment, logging: false });
+  const response = await server.inject('/swagger');
 
-  const spec = JSON.parse(response.payload)
+  const spec = JSON.parse(response.payload);
 
-  const options = { sortKeys: true }
-  const output = yaml.safeDump(spec, options).trim()
+  const options = { sortKeys: true };
+  const output = yaml.safeDump(spec, options).trim();
 
-  console.log(output)
+  console.log(output); // eslint-disable-line no-console
 
-  await server.stop()
+  await server.stop();
 }
 
-main()
+main();

--- a/scripts/gen-secret
+++ b/scripts/gen-secret
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const crypto = require('crypto')
+const crypto = require('crypto');
 
-const secret = crypto.randomBytes(64)
-process.stdout.write(secret.toString('hex'))
+const secret = crypto.randomBytes(64);
+process.stdout.write(secret.toString('hex'));


### PR DESCRIPTION
Previously, `scripts/*` (also written in JavaScript) weren't picked up by the linter.

This PR explicitly includes them in the linter runs and configures ESLint to allow dev dependencies to be used inside of scripts. Additionally, existing linting issues are fixed.

⚠️ Based on changes in #2.