### PR TITLE
[#3] Create mock endpoint for "/licenses"

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,14 +1,14 @@
 // Load application config
 const logging = require('./logging');
-const secret = require('./secret');
+// const secret = require('./secret');
 const server = require('./server');
-const services = require('./services');
+// const services = require('./services');
 const swagger = require('./swagger');
 
 module.exports = {
   logging,
-  secret,
+  // secret,
   server,
-  services,
+  // services,
   swagger,
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,13 +2,13 @@
 const logging = require('./logging');
 // const secret = require('./secret');
 const server = require('./server');
-// const services = require('./services');
+const services = require('./services');
 const swagger = require('./swagger');
 
 module.exports = {
   logging,
   // secret,
   server,
-  // services,
+  services,
   swagger,
 };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,6 +59,15 @@ paths:
       summary: Get information
       tags:
         - info
+  /licenses:
+    get:
+      produces:
+        - application/json
+      responses:
+        default:
+          description: ''
+      tags:
+        - licenses
   /swagger:
     get:
       parameters:

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`license routes GET /licenses returns a list of licenses 1`] = `
+Array [
+  Object {
+    "code": "CC BY-SA 3.0",
+    "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
+  },
+]
+`;

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -2,8 +2,8 @@ const routes = [];
 
 const mockResponse = [
   {
-    "code": "CC BY-SA 3.0",
-    "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+    code: 'CC BY-SA 3.0',
+    url: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
   },
 ];
 
@@ -11,9 +11,7 @@ routes.push({
   path: '/licenses',
   method: 'GET',
   options: {},
-  handler: async (request, h) => {
-    return h.response(mockResponse);
-  },
+  handler: async (request, h) => h.response(mockResponse),
 });
 
 module.exports = routes;

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -1,0 +1,19 @@
+const routes = [];
+
+const mockResponse = [
+  {
+    "code": "CC BY-SA 3.0",
+    "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+  },
+];
+
+routes.push({
+  path: '/licenses',
+  method: 'GET',
+  options: {},
+  handler: async (request, h) => {
+    return h.response(mockResponse);
+  },
+});
+
+module.exports = routes;

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -18,7 +18,7 @@ describe('license routes', () => {
 
     async function subject() {
       return context.inject(options());
-    };
+    }
 
     it('returns a list of licenses', async () => {
       const response = await subject({});

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -1,0 +1,31 @@
+const setup = require('./__helpers__/setup');
+
+describe('license routes', () => {
+  let context;
+
+  beforeEach(async () => {
+    context = await setup();
+  });
+
+  afterEach(async () => {
+    await context.destroy();
+  });
+
+  describe('GET /licenses', () => {
+    function options() {
+      return { url: `/licenses`, method: 'GET' };
+    }
+
+    async function subject() {
+      return context.inject(options());
+    };
+
+    it('returns a list of licenses', async () => {
+      const response = await subject({});
+
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
This creates a mock endpoint with sample response for all requests that are prefixed with "/licenses"

```json
[
  {
    "code": "CC BY-SA 3.0",
    "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
  },
  ...
]
```