### PR TITLE
[#4] Create mock endpoint "/license"

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -68,6 +68,11 @@ paths:
   '/license/{file}':
     get:
       description: Returns the most liberal license for the given image
+      parameters:
+        - in: path
+          name: file
+          required: true
+          type: string
       produces:
         - application/json
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,13 +59,26 @@ paths:
       summary: Get information
       tags:
         - info
-  /licenses:
+  '/license/{file}':
     get:
+      description: Returns the most liberal license for the given image
       produces:
         - application/json
       responses:
         default:
           description: ''
+      summary: Image License
+      tags:
+        - license
+  /licenses:
+    get:
+      description: Returns a List of all Licenses
+      produces:
+        - application/json
+      responses:
+        default:
+          description: ''
+      summary: Licenses Index
       tags:
         - licenses
   /swagger:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,6 +4,12 @@ definitions:
   BadRequestErrorResponse:
     description: Bad Request
     properties: {}
+  CodeUrlModel:
+    properties:
+      code:
+        type: string
+      url:
+        type: string
   InfoShowResponse:
     properties:
       version:
@@ -67,6 +73,8 @@ paths:
       responses:
         default:
           description: ''
+          schema:
+            $ref: '#/definitions/CodeUrlModel'
       summary: Image License
       tags:
         - license
@@ -78,6 +86,10 @@ paths:
       responses:
         default:
           description: ''
+          schema:
+            items:
+              $ref: '#/definitions/CodeUrlModel'
+            type: array
       summary: Licenses Index
       tags:
         - licenses

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`license routes GET /license returns a list of licenses 1`] = `
-Object {
-  "code": "CC BY-SA 3.0",
-  "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
-}
-`;
-
 exports[`license routes GET /license returns the license of a file 1`] = `
 Object {
   "code": "CC BY-SA 3.0",

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`license routes GET /license returns a list of licenses 1`] = `
+Object {
+  "code": "CC BY-SA 3.0",
+  "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
+}
+`;
+
 exports[`license routes GET /licenses returns a list of licenses 1`] = `
 Array [
   Object {

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -7,6 +7,13 @@ Object {
 }
 `;
 
+exports[`license routes GET /license returns the license of a file 1`] = `
+Object {
+  "code": "CC BY-SA 3.0",
+  "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
+}
+`;
+
 exports[`license routes GET /licenses returns a list of licenses 1`] = `
 Array [
   Object {

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -10,8 +10,21 @@ const mockResponse = [
 routes.push({
   path: '/licenses',
   method: 'GET',
-  options: {},
+  options: {
+    description: 'Licenses Index',
+    notes: 'Returns a List of all Licenses',
+  },
   handler: async (request, h) => h.response(mockResponse),
+});
+
+routes.push({
+  path: '/license/{file}',
+  method: 'GET',
+  options: {
+    description: 'Image License',
+    notes: 'Returns the most liberal license for the given image',
+  },
+  handler: async (request, h) => h.response(mockResponse[0]),
 });
 
 module.exports = routes;

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -20,7 +20,7 @@ routes.push({
       schema: Joi.array().items(
         Joi.object().keys({
           code: Joi.string(),
-          url: Joi.string()
+          url: Joi.string(),
         })
       ),
     },
@@ -36,13 +36,13 @@ routes.push({
     notes: 'Returns the most liberal license for the given image',
     validate: {
       params: {
-        file: Joi.string()
-      }
+        file: Joi.string(),
+      },
     },
     response: {
       schema: Joi.object().keys({
         code: Joi.string(),
-        url: Joi.string()
+        url: Joi.string(),
       }),
     },
   },

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -1,3 +1,5 @@
+const Joi = require('joi');
+
 const routes = [];
 
 const mockResponse = [
@@ -13,6 +15,15 @@ routes.push({
   options: {
     description: 'Licenses Index',
     notes: 'Returns a List of all Licenses',
+    validate: {},
+    response: {
+      schema: Joi.array().items(
+        Joi.object().keys({
+          code: Joi.string(),
+          url: Joi.string()
+        })
+      ),
+    },
   },
   handler: async (request, h) => h.response(mockResponse),
 });
@@ -23,6 +34,13 @@ routes.push({
   options: {
     description: 'Image License',
     notes: 'Returns the most liberal license for the given image',
+    validate: {},
+    response: {
+      schema: Joi.object().keys({
+        code: Joi.string(),
+        url: Joi.string()
+      }),
+    },
   },
   handler: async (request, h) => h.response(mockResponse[0]),
 });

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -34,7 +34,11 @@ routes.push({
   options: {
     description: 'Image License',
     notes: 'Returns the most liberal license for the given image',
-    validate: {},
+    validate: {
+      params: {
+        file: Joi.string()
+      }
+    },
     response: {
       schema: Joi.object().keys({
         code: Joi.string(),

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -28,4 +28,22 @@ describe('license routes', () => {
       expect(response.payload).toMatchSnapshot();
     });
   });
+
+  describe('GET /license', () => {
+    function options() {
+      return { url: `/license/File:Pommes-1.jpg`, method: 'GET' };
+    }
+
+    async function subject() {
+      return context.inject(options());
+    }
+
+    it('returns a list of licenses', async () => {
+      const response = await subject({});
+
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
+  });
 });

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -30,15 +30,17 @@ describe('license routes', () => {
   });
 
   describe('GET /license', () => {
+    const file = 'File:Pommes-1.jpg';
+
     function options() {
-      return { url: `/license/File:Pommes-1.jpg`, method: 'GET' };
+      return { url: `/license/{file}`, method: 'GET' };
     }
 
     async function subject() {
       return context.inject(options());
     }
 
-    it('returns a list of licenses', async () => {
+    it('returns the license of a file', async () => {
       const response = await subject({});
 
       expect(response.status).toBe(200);

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -33,7 +33,7 @@ describe('license routes', () => {
     const file = 'File:Pommes-1.jpg';
 
     function options() {
-      return { url: `/license/{file}`, method: 'GET' };
+      return { url: `/license/${file}`, method: 'GET' };
     }
 
     async function subject() {


### PR DESCRIPTION
This creates a mock endpoint with sample response for all requests that are prefixed with "/license"
```json
{ 
  "code": "CC BY-SA 3.0",
  "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
}
```