### PR TITLE
[#1] Create mock endpoint for "/attribution"

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,19 +12,25 @@ definitions:
         type: string
     required:
       - version
-  UnauthorizedErrorResponse:
-    description: Unauthorized
-    properties: {}
 host: TODO
 info:
   description: Create attribution hints for images from Wikipedia and Wikimedia Commons.
   title: attribution-generator-api
   version: 0.1.0
 paths:
-  '/attribution/{file}/and-so-on':
+  '/attribution/{language}/{file}':
     get:
       description: Generate attribution hints for the given file.
       operationId: attribution.show
+      parameters:
+        - in: path
+          name: language
+          required: true
+          type: string
+        - in: path
+          name: file
+          required: true
+          type: string
       produces:
         - application/json
       responses:
@@ -32,10 +38,6 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/BadRequestErrorResponse'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/UnauthorizedErrorResponse'
         default:
           description: ''
           schema:

--- a/routes/__snapshots__/attribution.test.js.snap
+++ b/routes/__snapshots__/attribution.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`attribution routes GET /attribution/… returns an attribution for the given file 1`] = `
+Object {
+  "attribution_html": "Pierre Dalous (https://commons.wikimedia.org/wiki/File:Pair_of_Merops_apiaster_feeding.jpg), \\"Pair of Merops apiaster feeding\\", https://creativecommons.org/licenses/by-sa/3.0/legalcode",
+  "attribution_plain": "Pierre Dalous (https://commons.wikimedia.org/wiki/File:Pair_of_Merops_apiaster_feeding.jpg), \\"Pair of Merops apiaster feeding\\", https://creativecommons.org/licenses/by-sa/3.0/legalcode",
+  "attribution_text": "Pierre Dalous (https://commons.wikimedia.org/wiki/File:Pair_of_Merops_apiaster_feeding.jpg), \\"Pair of Merops apiaster feeding\\", https://creativecommons.org/licenses/by-sa/3.0/legalcode",
+  "license": "CC BY-SA 3.0",
+  "license_url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
+}
+`;

--- a/routes/attribution.js
+++ b/routes/attribution.js
@@ -5,20 +5,34 @@ const prefix = require('./__utils__/path')('/attribution');
 
 const routes = [];
 
+const attributionMock = {
+  license: 'CC BY-SA 3.0',
+  attribution_plain:
+    'Pierre Dalous (https://commons.wikimedia.org/wiki/File:Pair_of_Merops_apiaster_feeding.jpg), "Pair of Merops apiaster feeding", https://creativecommons.org/licenses/by-sa/3.0/legalcode',
+  attribution_text:
+    'Pierre Dalous (https://commons.wikimedia.org/wiki/File:Pair_of_Merops_apiaster_feeding.jpg), "Pair of Merops apiaster feeding", https://creativecommons.org/licenses/by-sa/3.0/legalcode',
+  attribution_html:
+    'Pierre Dalous (https://commons.wikimedia.org/wiki/File:Pair_of_Merops_apiaster_feeding.jpg), "Pair of Merops apiaster feeding", https://creativecommons.org/licenses/by-sa/3.0/legalcode',
+  license_url: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
+};
 routes.push({
-  path: prefix('/{file}/and-so-on'),
+  path: prefix('/{language}/{file}'),
   method: 'GET',
   options: {
     description: 'Generate attribution',
     notes: 'Generate attribution hints for the given file.',
-    validate: {},
+    validate: {
+      params: {
+        language: Joi.string(),
+        file: Joi.string(),
+      },
+    },
     response: {
       schema: Joi.object()
         .required()
         .meta({ className: 'AttributionShowResponse' }),
       status: {
         400: definitions.errors['400'],
-        401: definitions.errors['401'],
       },
     },
     plugins: {
@@ -28,13 +42,7 @@ routes.push({
       },
     },
   },
-  handler: async (request, h) => {
-    // const { generator } = request.server.app.services;
-
-    const attribution = {};
-
-    return h.response(attribution);
-  },
+  handler: async (request, h) => h.response(attributionMock),
 });
 
 module.exports = routes;

--- a/routes/attribution.test.js
+++ b/routes/attribution.test.js
@@ -15,9 +15,9 @@ describe('attribution routes', () => {
 
   describe('GET /attribution/…', () => {
     function options(overrides = {}) {
-      const defaults = { file: 'File:…' };
+      const defaults = { language: 'en', file: 'File:…' };
       const params = { ...defaults, ...overrides };
-      return { url: `/attribution/${params.file}/…`, method: 'GET' };
+      return { url: `/attribution/${params.language}/${params.file}`, method: 'GET' };
     }
 
     async function subject(overrides = {}) {
@@ -26,6 +26,14 @@ describe('attribution routes', () => {
 
     afterEach(() => {
       generator.generate.mockReset();
+    });
+
+    it('returns an attribution for the given file', async () => {
+      const response = await subject({});
+
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
     });
 
     // eslint-disable-next-line jest/no-disabled-tests


### PR DESCRIPTION
Update the existing `attribution` endpoint to returns some static example data. I kept most of the boilerplate (e.g. in the tests), as we'll probably need it for the further adaption of the endpoint.

I also added some params - just because I was curious how this behaves and looks like.