### PR TITLE
[#14] Add error handling to "/files" endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,7 +59,7 @@ paths:
       summary: Generate attribution
       tags:
         - attribution
-  '/files/{pageUrl}':
+  '/files/{articleUrl}':
     get:
       description: Retrieve all files for a given article or page url.
       operationId: files.index

--- a/routes/__snapshots__/files.test.js.snap
+++ b/routes/__snapshots__/files.test.js.snap
@@ -24,6 +24,14 @@ Object {
 }
 `;
 
+exports[`files routes GET /files returns a 503 response when the wiki api is not reachable 1`] = `
+Object {
+  "error": "Service Unavailable",
+  "message": "api-unavailable",
+  "statusCode": 503,
+}
+`;
+
 exports[`files routes GET /files returns a list of all files from the given article 1`] = `
 Array [
   Object {

--- a/routes/__snapshots__/files.test.js.snap
+++ b/routes/__snapshots__/files.test.js.snap
@@ -1,46 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`files routes GET /files with a valid encoded url returns a list of files with their name and url 1`] = `
+exports[`files routes GET /files returns 422 response if the URL is invalid 1`] = `
+Object {
+  "error": "Unprocessable Entity",
+  "message": "invalid-url",
+  "statusCode": 422,
+}
+`;
+
+exports[`files routes GET /files returns a 404 when called with an unencoded articleUrl 1`] = `
+Object {
+  "error": "Not Found",
+  "message": "Not Found",
+  "statusCode": 404,
+}
+`;
+
+exports[`files routes GET /files returns a 500 response for a generic error 1`] = `
+Object {
+  "error": "Internal Server Error",
+  "message": "An internal server error occurred",
+  "statusCode": 500,
+}
+`;
+
+exports[`files routes GET /files returns a list of all files from the given article 1`] = `
 Array [
   Object {
-    "title": "File:Folder Hexagonal Icon.svg",
-    "url": "https://upload.wikimedia.org/wikipedia/en/4/48/Folder_Hexagonal_Icon.svg",
-  },
-  Object {
-    "title": "File:Flag of the United States.svg",
-    "url": "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
-  },
-  Object {
-    "title": "File:Commons-logo.svg",
-    "url": "https://upload.wikimedia.org/wikipedia/en/4/4a/Commons-logo.svg",
-  },
-  Object {
-    "title": "File:149 New Montgomery Street, San Francisco.jpg",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/8/8f/149_New_Montgomery_Street%2C_San_Francisco.jpg",
-  },
-  Object {
-    "title": "File:Blue pencil.svg",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/7/73/Blue_pencil.svg",
-  },
-  Object {
-    "title": "File:Christophe Henner défend son bilan.JPG",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/c/c4/Christophe_Henner_d%C3%A9fend_son_bilan.JPG",
-  },
-  Object {
-    "title": "File:Crystal Clear app linneighborhood.svg",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/f/f9/Crystal_Clear_app_linneighborhood.svg",
-  },
-  Object {
-    "title": "File:Finance Meeting Paris 2012-02-18 n06.jpg",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/d/de/Finance_Meeting_Paris_2012-02-18_n06.jpg",
-  },
-  Object {
-    "title": "File:Flag of Florida.svg",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/f/f7/Flag_of_Florida.svg",
-  },
-  Object {
-    "title": "File:Free and open-source software logo (2009).svg",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/3/31/Free_and_open-source_software_logo_%282009%29.svg",
+    "file": "File:image.jpg",
+    "url": "https://en.wikipedia.org/wiki/File:image.jpg",
   },
 ]
 `;

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -24,6 +24,14 @@ Object {
 }
 `;
 
+exports[`license routes GET /license returns a 503 response when the wiki api is not reachable 1`] = `
+Object {
+  "error": "Service Unavailable",
+  "message": "api-unavailable",
+  "statusCode": 503,
+}
+`;
+
 exports[`license routes GET /license returns the license of a file 1`] = `
 Object {
   "code": "CC BY-SA 3.0",

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -1,6 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`license routes GET /license when the license can be retrieved returns the license of a file 1`] = `
+exports[`license routes GET /license returns a 404 response when the license cannot be retrieved 1`] = `
+Object {
+  "error": "Not Found",
+  "message": "empty-response",
+  "statusCode": 404,
+}
+`;
+
+exports[`license routes GET /license returns a 422 response when the identifier cannot be parsed 1`] = `
+Object {
+  "error": "Unprocessable Entity",
+  "message": "invalid-url",
+  "statusCode": 422,
+}
+`;
+
+exports[`license routes GET /license returns a 500 response for any generic error 1`] = `
+Object {
+  "error": "Internal Server Error",
+  "message": "An internal server error occurred",
+  "statusCode": 500,
+}
+`;
+
+exports[`license routes GET /license returns the license of a file 1`] = `
 Object {
   "code": "CC BY-SA 3.0",
   "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",

--- a/routes/files.js
+++ b/routes/files.js
@@ -1,20 +1,18 @@
 const Joi = require('joi');
-const Boom = require('boom');
 
 const errors = require('../services/util/errors');
-
 const definitions = require('./__swagger__/definitions');
 
 const routes = [];
 
-function handleError({ message }) {
+function handleError(h, { message }) {
   switch (message) {
     case errors.invalidUrl:
-      throw new Boom(message, { statusCode: 422 });
+      return h.error(message, { statusCode: 422 });
     case errors.apiUnavailabe:
-      throw new Boom(message, { statusCode: 503 });
+      return h.error(message, { statusCode: 503 });
     default:
-      throw new Boom(message);
+      return h.error(message);
   }
 }
 
@@ -45,7 +43,7 @@ routes.push({
       const response = await files.getPageImages(articleUrl);
       return h.response(response);
     } catch (error) {
-      return handleError(error);
+      return handleError(h, error);
     }
   },
 });

--- a/routes/files.js
+++ b/routes/files.js
@@ -1,8 +1,18 @@
 const Joi = require('joi');
+const Boom = require('boom');
 
 const definitions = require('./__swagger__/definitions');
 
 const routes = [];
+
+function handleError(error) {
+  const { message } = error;
+  if (message === 'invalid-url') {
+    throw new Boom(error, { statusCode: 422 });
+  } else {
+    throw new Boom(error);
+  }
+}
 
 routes.push({
   path: '/files/{articleUrl}',
@@ -27,8 +37,12 @@ routes.push({
   handler: async (request, h) => {
     const { files } = request.server.app.services;
     const { articleUrl } = request.params;
-    const response = await files.getPageImages(articleUrl);
-    return h.response(response);
+    try {
+      const response = await files.getPageImages(articleUrl);
+      return h.response(response);
+    } catch (error) {
+      return handleError(error);
+    }
   },
 });
 

--- a/routes/files.js
+++ b/routes/files.js
@@ -6,10 +6,13 @@ const definitions = require('./__swagger__/definitions');
 const routes = [];
 
 function handleError({ message }) {
-  if (message === 'invalid-url') {
-    throw new Boom(message, { statusCode: 422 });
-  } else {
-    throw new Boom(message);
+  switch (message) {
+    case 'invalid-url':
+      throw new Boom(message, { statusCode: 422 });
+    case 'api-unavailable':
+      throw new Boom(message, { statusCode: 503 });
+    default:
+      throw new Boom(message);
   }
 }
 

--- a/routes/files.js
+++ b/routes/files.js
@@ -5,12 +5,11 @@ const definitions = require('./__swagger__/definitions');
 
 const routes = [];
 
-function handleError(error) {
-  const { message } = error;
+function handleError({ message }) {
   if (message === 'invalid-url') {
-    throw new Boom(error, { statusCode: 422 });
+    throw new Boom(message, { statusCode: 422 });
   } else {
-    throw new Boom(error);
+    throw new Boom(message);
   }
 }
 

--- a/routes/files.js
+++ b/routes/files.js
@@ -5,7 +5,7 @@ const definitions = require('./__swagger__/definitions');
 const routes = [];
 
 routes.push({
-  path: '/files/{pageUrl}',
+  path: '/files/{articleUrl}',
   method: 'GET',
   options: {
     description: 'Get all files for an article',
@@ -26,7 +26,8 @@ routes.push({
   },
   handler: async (request, h) => {
     const { files } = request.server.app.services;
-    const response = await files.getPageImages(request.params.pageUrl);
+    const { articleUrl } = request.params;
+    const response = await files.getPageImages(articleUrl);
     return h.response(response);
   },
 });

--- a/routes/files.js
+++ b/routes/files.js
@@ -1,15 +1,17 @@
 const Joi = require('joi');
 const Boom = require('boom');
 
+const errors = require('../services/util/errors');
+
 const definitions = require('./__swagger__/definitions');
 
 const routes = [];
 
 function handleError({ message }) {
   switch (message) {
-    case 'invalid-url':
+    case errors.invalidUrl:
       throw new Boom(message, { statusCode: 422 });
-    case 'api-unavailable':
+    case errors.apiUnavailabe:
       throw new Boom(message, { statusCode: 503 });
     default:
       throw new Boom(message);

--- a/routes/files.test.js
+++ b/routes/files.test.js
@@ -19,10 +19,10 @@ describe('files routes', () => {
       return context.inject({ ...defaults, ...options });
     }
 
-    const pageUrl = 'https://en.wikipedia.org/wiki/Wikimedia_Foundation';
+    const articleUrl = 'https://en.wikipedia.org/wiki/Wikimedia_Foundation';
 
     describe('with a valid encoded url', () => {
-      const encodedPageUrl = encodeURIComponent(pageUrl);
+      const encodedPageUrl = encodeURIComponent(articleUrl);
       const files = [
         { file: 'File:image.jpg', url: 'https://en.wikipedia.org/wiki/File:image.jpg' },
       ];
@@ -39,7 +39,7 @@ describe('files routes', () => {
 
     describe('with an unencoded url', () => {
       it('returns a 404', async () => {
-        const response = await subject({ url: `/files/${pageUrl}` });
+        const response = await subject({ url: `/files/${articleUrl}` });
         expect(response.status).toBe(404);
       });
     });

--- a/routes/files.test.js
+++ b/routes/files.test.js
@@ -1,5 +1,7 @@
 const setup = require('./__helpers__/setup');
 
+const errors = require('../services/util/errors');
+
 describe('files routes', () => {
   const files = { getPageImages: jest.fn() };
   const services = { files };
@@ -40,7 +42,7 @@ describe('files routes', () => {
     it('returns 422 response if the URL is invalid', async () => {
       const articleUrl = 'something-invalid';
       files.getPageImages.mockImplementation(() => {
-        throw new Error('invalid-url');
+        throw new Error(errors.invalidUrl);
       });
 
       const response = await subject({ url: `/files/${articleUrl}` });
@@ -68,7 +70,7 @@ describe('files routes', () => {
     it('returns a 503 response when the wiki api is not reachable', async () => {
       const articleUrl = 'something-random';
       files.getPageImages.mockImplementation(() => {
-        throw new Error('api-unavailable');
+        throw new Error(errors.apiUnavailabe);
       });
 
       const response = await subject({ url: `/files/${articleUrl}` });

--- a/routes/files.test.js
+++ b/routes/files.test.js
@@ -65,6 +65,20 @@ describe('files routes', () => {
       expect(response.payload).toMatchSnapshot();
     });
 
+    it('returns a 503 response when the wiki api is not reachable', async () => {
+      const articleUrl = 'something-random';
+      files.getPageImages.mockImplementation(() => {
+        throw new Error('api-unavailable');
+      });
+
+      const response = await subject({ url: `/files/${articleUrl}` });
+
+      expect(files.getPageImages).toHaveBeenCalledWith(articleUrl);
+      expect(response.status).toBe(503);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
+
     it('returns a 404 when called with an unencoded articleUrl', async () => {
       const articleUrl = 'https://en.wikipedia.org/wiki/Wikimedia_Foundation';
 

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -1,5 +1,4 @@
 const Joi = require('joi');
-const Boom = require('boom');
 
 const errors = require('../services/util/errors');
 
@@ -10,16 +9,16 @@ const licenseSchema = Joi.object({
   code: Joi.string(),
 });
 
-function handleError({ message }) {
+function handleError(h, { message }) {
   switch (message) {
     case errors.invalidUrl:
-      throw new Boom(message, { statusCode: 422 });
+      return h.error(message, { statusCode: 422 });
     case errors.emptyResponse:
-      throw new Boom(message, { statusCode: 404 });
+      return h.error(message, { statusCode: 404 });
     case errors.apiUnavailabe:
-      throw new Boom(message, { statusCode: 503 });
+      return h.error(message, { statusCode: 503 });
     default:
-      throw new Boom(message);
+      return h.error(message);
   }
 }
 
@@ -93,7 +92,7 @@ routes.push({
       const response = { url: encodeURI(license.url), code: license.name };
       return h.response(response);
     } catch (error) {
-      return handleError(error);
+      return handleError(h, error);
     }
   },
 });

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -1,4 +1,5 @@
 const Joi = require('joi');
+const Boom = require('boom');
 
 const routes = [];
 
@@ -6,6 +7,17 @@ const licenseSchema = Joi.object({
   url: Joi.string().uri(),
   code: Joi.string(),
 });
+
+function handleError({ message }) {
+  switch (message) {
+    case 'invalid-url':
+      throw new Boom(message, { statusCode: 422 });
+    case 'empty-response':
+      throw new Boom(message, { statusCode: 404 });
+    default:
+      throw new Boom(message);
+  }
+}
 
 routes.push({
   path: '/licenses/compatible/{license}',
@@ -77,8 +89,7 @@ routes.push({
       const response = { url: encodeURI(license.url), code: license.name };
       return h.response(response);
     } catch (error) {
-      const { message } = error;
-      return h.error(message);
+      return handleError(error);
     }
   },
 });

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -14,6 +14,8 @@ function handleError({ message }) {
       throw new Boom(message, { statusCode: 422 });
     case 'empty-response':
       throw new Boom(message, { statusCode: 404 });
+    case 'api-unavailable':
+      throw new Boom(message, { statusCode: 503 });
     default:
       throw new Boom(message);
   }

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -1,6 +1,8 @@
 const Joi = require('joi');
 const Boom = require('boom');
 
+const errors = require('../services/util/errors');
+
 const routes = [];
 
 const licenseSchema = Joi.object({
@@ -10,11 +12,11 @@ const licenseSchema = Joi.object({
 
 function handleError({ message }) {
   switch (message) {
-    case 'invalid-url':
+    case errors.invalidUrl:
       throw new Boom(message, { statusCode: 422 });
-    case 'empty-response':
+    case errors.emptyResponse:
       throw new Boom(message, { statusCode: 404 });
-    case 'api-unavailable':
+    case errors.apiUnavailabe:
       throw new Boom(message, { statusCode: 503 });
     default:
       throw new Boom(message);

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -149,5 +149,19 @@ describe('license routes', () => {
       expect(response.type).toBe('application/json');
       expect(response.payload).toMatchSnapshot();
     });
+
+    it('returns a 503 response when the wiki api is not reachable', async () => {
+      fileData.getFileData.mockImplementation(() => {
+        throw new Error('api-unavailable');
+      });
+
+      const response = await subject({});
+
+      expect(fileData.getFileData).toHaveBeenCalledWith(title);
+      expect(licenses.getLicense).not.toHaveBeenCalled();
+      expect(response.status).toBe(503);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
   });
 });

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -1,5 +1,7 @@
 const setup = require('./__helpers__/setup');
 
+const errors = require('../services/util/errors');
+
 describe('license routes', () => {
   let context;
 
@@ -110,7 +112,7 @@ describe('license routes', () => {
 
     it('returns a 404 response when the license cannot be retrieved', async () => {
       fileData.getFileData.mockImplementation(() => {
-        throw new Error('empty-response');
+        throw new Error(errors.emptyResponse);
       });
 
       const response = await subject({});
@@ -124,7 +126,7 @@ describe('license routes', () => {
 
     it('returns a 422 response when the identifier cannot be parsed', async () => {
       fileData.getFileData.mockImplementation(() => {
-        throw new Error('invalid-url');
+        throw new Error(errors.invalidUrl);
       });
 
       const response = await subject({});
@@ -152,7 +154,7 @@ describe('license routes', () => {
 
     it('returns a 503 response when the wiki api is not reachable', async () => {
       fileData.getFileData.mockImplementation(() => {
-        throw new Error('api-unavailable');
+        throw new Error(errors.apiUnavailabe);
       });
 
       const response = await subject({});

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ const Hapi = require('hapi');
 const HapiRouter = require('hapi-router');
 const HapiSwagger = require('hapi-swaggered');
 
-const Boom = require('boom');
 const Good = require('good');
 
 async function init(environment) {
@@ -17,11 +16,6 @@ async function init(environment) {
   server.app.services = services;
 
   // Extend Hapi response toolkit and request interfaces.
-  // eslint-disable-next-line prefer-arrow-callback
-  server.decorate('toolkit', 'error', function error(name, ...args) {
-    throw Boom[name](...args);
-  });
-
   server.decorate('toolkit', 'assert', function assert(value, err, ...args) {
     if (!value) this.error(err, ...args);
   });

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const HapiRouter = require('hapi-router');
 const HapiSwagger = require('hapi-swaggered');
 
 const Good = require('good');
+const Boom = require('boom');
 
 async function init(environment) {
   const { logging, secret, server: options, services, swagger } = environment;
@@ -16,6 +17,10 @@ async function init(environment) {
   server.app.services = services;
 
   // Extend Hapi response toolkit and request interfaces.
+  server.decorate('toolkit', 'error', (message, ...args) => {
+    throw new Boom(message, ...args);
+  });
+
   server.decorate('toolkit', 'assert', function assert(value, err, ...args) {
     if (!value) this.error(err, ...args);
   });

--- a/services/__fixtures__/imageTitlesMissing.js
+++ b/services/__fixtures__/imageTitlesMissing.js
@@ -1,0 +1,15 @@
+module.exports = {
+  normalized: [
+    {
+      from: 'Article_Title',
+      to: 'Article Title',
+    },
+  ],
+  pages: {
+    848165: {
+      pageid: 848165,
+      ns: 0,
+      title: 'Article Title',
+    },
+  },
+};

--- a/services/__snapshots__/files.test.js.snap
+++ b/services/__snapshots__/files.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Files getPageImages() parses the url and retrieves all images for the article 1`] = `
+exports[`Files getPageImages() with a valid wikipedia url returns a list of all images from the given article 1`] = `
 Array [
   Object {
     "title": "File:Graphic 01.jpg",

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -8,9 +8,10 @@ const filePrefix = 'File:';
 const defaultWikiUrl = 'https://commons.wikimedia.org/';
 
 function parseImageInfoResponse(response) {
-  const { pages } = response;
-  assert.ok(pages, errors.emptyResponse);
-  const { imageinfo } = Object.values(pages)[0];
+  assert.ok(response.pages, errors.emptyResponse);
+  const pages = Object.values(response.pages);
+  assert.ok(pages.length === 1);
+  const { imageinfo } = pages[0];
   return imageinfo[0];
 }
 

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 
 const parseWikiUrl = require('./util/parseWikiUrl');
+const errors = require('./util/errors');
 
 const urlRegex = /^(https|http)?:\/\//;
 const filePrefix = 'File:';
@@ -8,13 +9,13 @@ const defaultWikiUrl = 'https://commons.wikimedia.org/';
 
 function parseImageInfoResponse(response) {
   const { pages } = response;
-  assert.ok(pages, 'empty-response');
+  assert.ok(pages, errors.emptyResponse);
   const { imageinfo } = Object.values(pages)[0];
   return imageinfo[0];
 }
 
 function parseFileTitle(title) {
-  assert.ok(title.startsWith(filePrefix), 'invalid-url');
+  assert.ok(title.startsWith(filePrefix), errors.invalidUrl);
   return { title, wikiUrl: defaultWikiUrl };
 }
 

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -8,13 +8,13 @@ const defaultWikiUrl = 'https://commons.wikimedia.org/';
 
 function parseImageInfoResponse(response) {
   const { pages } = response;
-  assert.ok(pages, 'notFound');
+  assert.ok(pages, 'empty-response');
   const { imageinfo } = Object.values(pages)[0];
   return imageinfo[0];
 }
 
 function parseFileTitle(title) {
-  assert.ok(title.startsWith(filePrefix), 'badData');
+  assert.ok(title.startsWith(filePrefix), 'invalid-url');
   return { title, wikiUrl: defaultWikiUrl };
 }
 

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -31,26 +31,20 @@ async function getImageInfo({ client, title, wikiUrl }) {
   return parseImageInfoResponse(response);
 }
 
-async function getOriginalFileData({ client, ...params }) {
-  const imageInfo = await getImageInfo({ client, ...params });
-  const { url, extmetadata } = imageInfo;
-  const { title, wikiUrl } = parseWikiUrl(url);
-  const { value: artistHtml = null } = extmetadata.Artist || {};
-
-  return { title, wikiUrl, artistHtml };
-}
-
 class FileData {
   constructor({ client }) {
     this.client = client;
   }
 
   async getFileData(titleOrUrl) {
+    const { client } = this;
     const identifier = decodeURIComponent(titleOrUrl);
     const { title, wikiUrl } = parseIdentifier(identifier);
-    const { client } = this;
+    const { url, extmetadata } = await getImageInfo({ client, title, wikiUrl });
+    const { title: originalTitle, wikiUrl: originalWikiUrl } = parseWikiUrl(url);
+    const { value: artistHtml = null } = extmetadata.Artist || {};
 
-    return getOriginalFileData({ client, title, wikiUrl });
+    return { title: originalTitle, wikiUrl: originalWikiUrl, artistHtml };
   }
 }
 

--- a/services/fileData.test.js
+++ b/services/fileData.test.js
@@ -1,5 +1,6 @@
 const FileData = require('./fileData');
 
+const errors = require('../services/util/errors');
 const imageInfoMock = require('./__fixtures__/imageInfo');
 const imageInfoWithoutArtistMock = require('./__fixtures__/imageInfoWithoutArtist');
 
@@ -48,7 +49,7 @@ describe('FileData', () => {
 
         const service = new FileData({ client });
 
-        await expect(service.getFileData(url)).rejects.toThrow('empty-response');
+        await expect(service.getFileData(url)).rejects.toThrow(errors.emptyResponse);
       });
     });
 
@@ -68,11 +69,10 @@ describe('FileData', () => {
       });
 
       it('throws an exception when the title has the wrong format', async () => {
-        const message = 'invalid-url';
         const service = new FileData({ client });
         const badTitle = 'Apple_Lisa2-IMG_1517.jpg';
 
-        await expect(service.getFileData(badTitle)).rejects.toThrow(message);
+        await expect(service.getFileData(badTitle)).rejects.toThrow(errors.invalidUrl);
       });
     });
   });

--- a/services/fileData.test.js
+++ b/services/fileData.test.js
@@ -43,12 +43,12 @@ describe('FileData', () => {
         expect(fileData).toEqual({ title, wikiUrl, artistHtml: null });
       });
 
-      it('throws a notFound error when the imageinfo response is empty', async () => {
+      it('throws an error when the imageinfo response is empty', async () => {
         client.getResultsFromApi.mockResolvedValueOnce({});
 
         const service = new FileData({ client });
 
-        await expect(service.getFileData(url)).rejects.toThrow('notFound');
+        await expect(service.getFileData(url)).rejects.toThrow('empty-response');
       });
     });
 
@@ -68,10 +68,11 @@ describe('FileData', () => {
       });
 
       it('throws an exception when the title has the wrong format', async () => {
+        const message = 'invalid-url';
         const service = new FileData({ client });
         const badTitle = 'Apple_Lisa2-IMG_1517.jpg';
 
-        await expect(service.getFileData(badTitle)).rejects.toThrow('badData');
+        await expect(service.getFileData(badTitle)).rejects.toThrow(message);
       });
     });
   });

--- a/services/files.js
+++ b/services/files.js
@@ -1,17 +1,19 @@
 const assert = require('assert');
 
-const parse = require('./util/parseWikiUrl');
+const parseWikiUrl = require('./util/parseWikiUrl');
 
-function formatImagesInfoResponse(response) {
+function formatImageInfo(page) {
+  const { title, imageinfo } = page;
+  const { url } = imageinfo[0];
+  return { title, url };
+}
+
+function parseImageInfoResponse(response) {
   const { pages } = response;
   assert.ok(!!pages, 'Wikimedia: No "url" option provided');
 
-  // TODO: use response wrapper to extract data (ImageInfo)
-  return Object.values(pages).map(page => {
-    const { title, imageinfo } = page;
-    const { url } = imageinfo[0];
-    return { title, url };
-  });
+  // TODO: raise error when length === 1
+  return Object.values(pages).map(formatImageInfo);
 }
 
 class Files {
@@ -20,25 +22,25 @@ class Files {
   }
 
   async getPageImages(url) {
-    const { title, wikiUrl } = parse(url);
-    const imageTitles = await this.getImageTitles(title, wikiUrl);
+    const { title, wikiUrl } = parseWikiUrl(url);
+    const titles = await this.getImageTitles({ title, wikiUrl });
 
-    return this.getImagesInfo(imageTitles, wikiUrl);
+    return this.getImageUrls({ titles, wikiUrl });
   }
 
   // TODO: handle no images found
-  async getImageTitles(pageTitle, wikiUrl) {
-    const response = await this.client.getResultsFromApi(pageTitle, 'images', wikiUrl);
+  async getImageTitles({ title, wikiUrl }) {
+    const response = await this.client.getResultsFromApi(title, 'images', wikiUrl);
     const page = Object.values(response.pages)[0];
     return page.images.map(image => image.title);
   }
 
   // TODO: what happens with too long titles (too many images)
-  async getImagesInfo(images, wikiUrl) {
+  async getImageUrls({ titles, wikiUrl }) {
     const params = { iiprop: 'url' };
-    const titles = images.join('|');
-    const response = await this.client.getResultsFromApi(titles, 'imageinfo', wikiUrl, params);
-    return formatImagesInfoResponse(response);
+    const title = titles.join('|');
+    const response = await this.client.getResultsFromApi(title, 'imageinfo', wikiUrl, params);
+    return parseImageInfoResponse(response);
   }
 }
 

--- a/services/files.js
+++ b/services/files.js
@@ -4,9 +4,11 @@ const parseWikiUrl = require('./util/parseWikiUrl');
 const errors = require('./util/errors');
 
 async function getImageTitles({ client, title, wikiUrl }) {
-  const { pages } = await client.getResultsFromApi(title, 'images', wikiUrl);
-  assert.ok(pages, errors.emptyResponse);
-  const { images = [] } = Object.values(pages)[0];
+  const response = await client.getResultsFromApi(title, 'images', wikiUrl);
+  assert.ok(response.pages, errors.emptyResponse);
+  const pages = Object.values(response.pages);
+  assert.ok(pages.length === 1);
+  const { images = [] } = pages[0];
 
   return images.map(image => image.title);
 }

--- a/services/files.js
+++ b/services/files.js
@@ -4,7 +4,7 @@ const parseWikiUrl = require('./util/parseWikiUrl');
 
 async function getImageTitles({ client, title, wikiUrl }) {
   const { pages } = await client.getResultsFromApi(title, 'images', wikiUrl);
-  assert.ok(pages, 'notFound');
+  assert.ok(pages, 'empty-response');
   const { images = [] } = Object.values(pages)[0];
 
   return images.map(image => image.title);
@@ -21,7 +21,7 @@ async function getImageUrls({ client, titles, wikiUrl }) {
   const params = { iiprop: 'url' };
   const title = titles.join('|');
   const { pages } = await client.getResultsFromApi(title, 'imageinfo', wikiUrl, params);
-  assert.ok(pages, 'notFound');
+  assert.ok(pages, 'empty-response');
 
   return Object.values(pages).map(formatImageInfo);
 }

--- a/services/files.js
+++ b/services/files.js
@@ -1,10 +1,11 @@
 const assert = require('assert');
 
 const parseWikiUrl = require('./util/parseWikiUrl');
+const errors = require('./util/errors');
 
 async function getImageTitles({ client, title, wikiUrl }) {
   const { pages } = await client.getResultsFromApi(title, 'images', wikiUrl);
-  assert.ok(pages, 'empty-response');
+  assert.ok(pages, errors.emptyResponse);
   const { images = [] } = Object.values(pages)[0];
 
   return images.map(image => image.title);
@@ -21,7 +22,7 @@ async function getImageUrls({ client, titles, wikiUrl }) {
   const params = { iiprop: 'url' };
   const title = titles.join('|');
   const { pages } = await client.getResultsFromApi(title, 'imageinfo', wikiUrl, params);
-  assert.ok(pages, 'empty-response');
+  assert.ok(pages, errors.emptyResponse);
 
   return Object.values(pages).map(formatImageInfo);
 }

--- a/services/files.test.js
+++ b/services/files.test.js
@@ -1,6 +1,7 @@
 const Files = require('./files');
 
 const parseWikiUrl = require('./util/parseWikiUrl');
+const errors = require('./util/errors');
 
 const imageTitles = require('./__fixtures__/imageTitles');
 const imageTitlesMissing = require('./__fixtures__/imageTitlesMissing');
@@ -18,10 +19,10 @@ describe('Files', () => {
 
     it('passes on the error if the url cannot be parsed', async () => {
       parseWikiUrl.mockImplementation(() => {
-        throw new Error('badData');
+        throw new Error(errors.invalidUrl);
       });
       const service = new Files({ client });
-      await expect(service.getPageImages(url)).rejects.toThrow('badData');
+      await expect(service.getPageImages(url)).rejects.toThrow(errors.invalidUrl);
     });
 
     describe('with a valid wikipedia url', () => {

--- a/services/licenses.js
+++ b/services/licenses.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 
+const errors = require('./util/errors');
+
 function normalizeTemplateTitle(template) {
   const { title } = template;
   return title.replace(/^Template:/, '');
@@ -7,7 +9,7 @@ function normalizeTemplateTitle(template) {
 
 function formatPageTemplateTitles(response) {
   const { pages } = response;
-  assert.ok(pages, 'empty-response');
+  assert.ok(pages, errors.emptyResponse);
   const { templates = [] } = Object.values(pages)[0];
   return templates.map(normalizeTemplateTitle);
 }

--- a/services/licenses.js
+++ b/services/licenses.js
@@ -8,9 +8,10 @@ function normalizeTemplateTitle(template) {
 }
 
 function formatPageTemplateTitles(response) {
-  const { pages } = response;
-  assert.ok(pages, errors.emptyResponse);
-  const { templates = [] } = Object.values(pages)[0];
+  assert.ok(response.pages, errors.emptyResponse);
+  const pages = Object.values(response.pages);
+  assert.ok(pages.length === 1);
+  const { templates = [] } = pages[0];
   return templates.map(normalizeTemplateTitle);
 }
 

--- a/services/licenses.js
+++ b/services/licenses.js
@@ -7,9 +7,15 @@ function normalizeTemplateTitle(template) {
 
 function formatPageTemplateTitles(response) {
   const { pages } = response;
-  assert.ok(pages, 'notFound');
+  assert.ok(pages, 'empty-response');
   const { templates = [] } = Object.values(pages)[0];
   return templates.map(normalizeTemplateTitle);
+}
+
+async function getPageTemplates({ client, title, wikiUrl }) {
+  const params = { tlnamespace: 10, tllimit: 100 };
+  const response = await client.getResultsFromApi(title, 'templates', wikiUrl, params);
+  return formatPageTemplateTitles(response);
 }
 
 class Licences {
@@ -19,15 +25,9 @@ class Licences {
   }
 
   async getLicense({ title, wikiUrl }) {
-    const templates = await this.getPageTemplates({ title, wikiUrl });
+    const { client } = this;
+    const templates = await getPageTemplates({ client, title, wikiUrl });
     return this.licenseStore.match(templates);
-  }
-
-  // TODO: add separate tests for this or indicated the method as private
-  async getPageTemplates({ title, wikiUrl }) {
-    const params = { tlnamespace: 10, tllimit: 100 };
-    const response = await this.client.getResultsFromApi(title, 'templates', wikiUrl, params);
-    return formatPageTemplateTitles(response);
   }
 }
 

--- a/services/licenses.test.js
+++ b/services/licenses.test.js
@@ -1,5 +1,6 @@
 const Licenses = require('./licenses');
 
+const errors = require('./util/errors');
 const templatesMock = require('./__fixtures__/templates');
 const templatesMissingMock = require('./__fixtures__/templatesMissing');
 
@@ -54,7 +55,7 @@ describe('Licenses', () => {
 
     it('throws an error if the response is fully empty', async () => {
       client.getResultsFromApi.mockResolvedValueOnce({});
-      await expect(service.getLicense({ title, wikiUrl })).rejects.toThrow('empty-response');
+      await expect(service.getLicense({ title, wikiUrl })).rejects.toThrow(errors.emptyResponse);
     });
   });
 });

--- a/services/licenses.test.js
+++ b/services/licenses.test.js
@@ -52,9 +52,9 @@ describe('Licenses', () => {
       expect(license).toBe(null);
     });
 
-    it('throws a notFound error if the response is fully empty', async () => {
+    it('throws an error if the response is fully empty', async () => {
       client.getResultsFromApi.mockResolvedValueOnce({});
-      await expect(service.getLicense({ title, wikiUrl })).rejects.toThrow('notFound');
+      await expect(service.getLicense({ title, wikiUrl })).rejects.toThrow('empty-response');
     });
   });
 });

--- a/services/util/client.js
+++ b/services/util/client.js
@@ -10,7 +10,7 @@ function transform(data) {
 }
 
 function handleError(error) {
-  if (error.request) throw new Error('serviceUnavailable');
+  if (error.request) throw new Error('api-unavailable');
   throw error;
 }
 

--- a/services/util/client.js
+++ b/services/util/client.js
@@ -9,6 +9,21 @@ function transform(data) {
   return query;
 }
 
+function handleError(error) {
+  if (error.request) throw new Error('serviceUnavailable');
+  throw error;
+}
+
+async function queryApi({ client, wikiUrl, params }) {
+  const apiUrl = Url.resolve(wikiUrl, apiPath);
+  try {
+    const { data } = await client.get(apiUrl, { params });
+    return transform(data);
+  } catch (error) {
+    return handleError(error);
+  }
+}
+
 class Client {
   constructor() {
     this.client = axios.create({
@@ -23,19 +38,14 @@ class Client {
   }
 
   getResultsFromApi(titles, prop, wikiUrl, params = {}) {
+    const { client } = this;
     const queryParams = {
       ...defaultParams,
       ...params,
       titles,
       prop,
     };
-    return this.query(wikiUrl, queryParams);
-  }
-
-  async query(wikiUrl, params) {
-    const apiUrl = Url.resolve(wikiUrl, apiPath);
-    const { data } = await this.client.get(apiUrl, { params });
-    return transform(data);
+    return queryApi({ client, wikiUrl, params: queryParams });
   }
 }
 

--- a/services/util/client.js
+++ b/services/util/client.js
@@ -10,7 +10,7 @@ function transform(data) {
 }
 
 function handleError(error) {
-  if (error.request) throw new Error('api-unavailable');
+  if (!error.response) throw new Error('api-unavailable');
   throw error;
 }
 

--- a/services/util/client.js
+++ b/services/util/client.js
@@ -1,6 +1,8 @@
 const axios = require('axios');
 const Url = require('url');
 
+const errors = require('./errors');
+
 const defaultParams = { action: 'query', format: 'json' };
 const apiPath = 'w/api.php';
 
@@ -10,7 +12,7 @@ function transform(data) {
 }
 
 function handleError(error) {
-  if (!error.response) throw new Error('api-unavailable');
+  if (!error.response) throw new Error(errors.apiUnavailabe);
   throw error;
 }
 

--- a/services/util/client.test.js
+++ b/services/util/client.test.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 
+const errors = require('./errors');
 const Client = require('./client');
 
 jest.mock('axios');
@@ -38,7 +39,7 @@ describe('Client', () => {
       const client = new Client();
 
       await expect(client.getResultsFromApi(titles, 'image', wikiUrl)).rejects.toThrow(
-        'api-unavailable'
+        errors.apiUnavailabe
       );
     });
 

--- a/services/util/client.test.js
+++ b/services/util/client.test.js
@@ -29,7 +29,7 @@ describe('Client', () => {
     const defaultParams = { action: 'query', format: 'json' };
     const mockedResponse = { data: { query: { foo: 'bar' } } };
 
-    it('returns a 503 if the API cannot be reached', async () => {
+    it('returns an error if the API cannot be reached', async () => {
       const titles = 'Def_Leppard';
       const error = { request: {} };
       axiosClient.get.mockImplementation(() => {
@@ -38,7 +38,7 @@ describe('Client', () => {
       const client = new Client();
 
       await expect(client.getResultsFromApi(titles, 'image', wikiUrl)).rejects.toThrow(
-        'serviceUnavailable'
+        'api-unavailable'
       );
     });
 

--- a/services/util/client.test.js
+++ b/services/util/client.test.js
@@ -7,9 +7,7 @@ jest.mock('axios');
 describe('Client', () => {
   const axiosClient = { get: jest.fn() };
 
-  beforeEach(() => {
-    axios.create.mockReturnValue(axiosClient);
-  });
+  beforeEach(() => axios.create.mockReturnValue(axiosClient));
 
   it('initializes a new axios client with defaults for header and timeout', () => {
     const headers = {
@@ -19,7 +17,6 @@ describe('Client', () => {
       },
     };
     const timeout = 5000;
-
     const subject = new Client();
 
     expect(axios.create).toHaveBeenCalledWith({ headers, timeout });
@@ -30,41 +27,60 @@ describe('Client', () => {
     const wikiUrl = 'https://en.wikipedia.org';
     const apiUrl = 'https://en.wikipedia.org/w/api.php';
     const defaultParams = { action: 'query', format: 'json' };
-    const response = { data: { query: { foo: 'bar' } } };
+    const mockedResponse = { data: { query: { foo: 'bar' } } };
 
-    beforeEach(() => {
-      axiosClient.get.mockResolvedValue(response);
+    it('returns a 503 if the API cannot be reached', async () => {
+      const titles = 'Def_Leppard';
+      const error = { request: {} };
+      axiosClient.get.mockImplementation(() => {
+        throw error;
+      });
+      const client = new Client();
+
+      await expect(client.getResultsFromApi(titles, 'image', wikiUrl)).rejects.toThrow(
+        'serviceUnavailable'
+      );
     });
 
-    describe('when querying for images of a page', () => {
+    it('passes on any errors from doing the request', async () => {
+      const titles = 'Def_Leppard';
+      axiosClient.get.mockImplementation(() => {
+        throw new Error();
+      });
+      const client = new Client();
+
+      await expect(client.getResultsFromApi(titles, 'image', wikiUrl)).rejects.toThrow();
+    });
+
+    it('allows querying for images of a page', async () => {
       const titles = 'Def_Leppard';
       const prop = 'image';
       const params = { ...defaultParams, prop, titles };
 
-      it('calls the respective api and returns the query result', async () => {
-        const client = new Client();
-        const subject = await client.getResultsFromApi(titles, 'image', wikiUrl);
+      axiosClient.get.mockResolvedValue(mockedResponse);
 
-        expect(axiosClient.get).toHaveBeenCalledWith(apiUrl, { params });
-        expect(subject).toEqual({ foo: 'bar' });
-      });
+      const client = new Client();
+      const subject = await client.getResultsFromApi(titles, 'image', wikiUrl);
+
+      expect(axiosClient.get).toHaveBeenCalledWith(apiUrl, { params });
+      expect(subject).toEqual({ foo: 'bar' });
     });
 
-    describe('when querying for imageInfo for a collection of images', () => {
+    it('allows querying for multiple titles with additional params', async () => {
       const titles = 'File:Steve_Clark.jpeg|File:RickAllen.JPG';
       const prop = 'imageInfo';
       const params = { ...defaultParams, prop, titles, iiprop: 'url' };
 
-      it('calls the respective api and returns the query result', async () => {
-        const client = new Client();
-        const subject = await client.getResultsFromApi(titles, prop, wikiUrl, {
-          titles,
-          iiprop: 'url',
-        });
+      axiosClient.get.mockResolvedValue(mockedResponse);
 
-        expect(axiosClient.get).toHaveBeenCalledWith(apiUrl, { params });
-        expect(subject).toEqual({ foo: 'bar' });
+      const client = new Client();
+      const subject = await client.getResultsFromApi(titles, prop, wikiUrl, {
+        titles,
+        iiprop: 'url',
       });
+
+      expect(axiosClient.get).toHaveBeenCalledWith(apiUrl, { params });
+      expect(subject).toEqual({ foo: 'bar' });
     });
   });
 });

--- a/services/util/errors.js
+++ b/services/util/errors.js
@@ -1,0 +1,5 @@
+module.exports = {
+  invalidUrl: 'invalid-url',
+  apiUnavailabe: 'api-unavailable',
+  emptyResponse: 'empty-response',
+};

--- a/services/util/parseWikiUrl.js
+++ b/services/util/parseWikiUrl.js
@@ -47,13 +47,17 @@ function splitUrl(url) {
   if (wikipediaRegExp.test(url)) {
     return splitWikipediaUrl(url);
   }
-  // TODO: use a dedicated Error object here
-  throw new Error('badData');
+  throw new Error('invalid-url');
 }
 
 function parse(url) {
-  const sanitizedUrl = decodeURI(url);
-  return splitUrl(sanitizedUrl);
+  try {
+    const sanitizedUrl = decodeURI(url);
+    return splitUrl(sanitizedUrl);
+  } catch (error) {
+    if (error instanceof URIError) throw new Error('invalid-url');
+    throw error;
+  }
 }
 
 module.exports = parse;

--- a/services/util/parseWikiUrl.js
+++ b/services/util/parseWikiUrl.js
@@ -1,3 +1,5 @@
+const errors = require('./errors');
+
 const wikipediaRegExp = /([-a-z]{2,})(\.m)?\.wikipedia\.org\//i;
 const uploadRegExp = /upload.wikimedia\.org\/wikipedia\/([-a-z]{2,})\//i;
 
@@ -47,7 +49,7 @@ function splitUrl(url) {
   if (wikipediaRegExp.test(url)) {
     return splitWikipediaUrl(url);
   }
-  throw new Error('invalid-url');
+  throw new Error(errors.invalidUrl);
 }
 
 function parse(url) {
@@ -55,7 +57,7 @@ function parse(url) {
     const sanitizedUrl = decodeURI(url);
     return splitUrl(sanitizedUrl);
   } catch (error) {
-    if (error instanceof URIError) throw new Error('invalid-url');
+    if (error instanceof URIError) throw new Error(errors.invalidUrl);
     throw error;
   }
 }

--- a/services/util/parseWikiUrl.test.js
+++ b/services/util/parseWikiUrl.test.js
@@ -1,4 +1,5 @@
 const parse = require('./parseWikiUrl');
+const errors = require('./errors');
 
 // according to https://en.wikipedia.org/wiki/Help:URL#URLs_of_Wikipedia_pages
 // and some upload urls
@@ -87,26 +88,26 @@ describe('parse()', () => {
 
   it('throws an exception for for non-wiki url', () => {
     const url = 'https://en.pokepedia.org/wiki/Lower_Saxony';
-    expect(() => parse(url)).toThrow('invalid-url');
+    expect(() => parse(url)).toThrow(errors.invalidUrl);
   });
 
   it('throws an exception for empty urls', () => {
     const url = '';
-    expect(() => parse(url)).toThrow('invalid-url');
+    expect(() => parse(url)).toThrow(errors.invalidUrl);
   });
 
   it('throws an exception for null urls', () => {
     const url = null;
-    expect(() => parse(url)).toThrow('invalid-url');
+    expect(() => parse(url)).toThrow(errors.invalidUrl);
   });
 
   it('throws an exception for undefined urls', () => {
     const url = undefined;
-    expect(() => parse(url)).toThrow('invalid-url');
+    expect(() => parse(url)).toThrow(errors.invalidUrl);
   });
 
   it('throws an exception for invalid urls', () => {
     const url = '%';
-    expect(() => parse(url)).toThrow('invalid-url');
+    expect(() => parse(url)).toThrow(errors.invalidUrl);
   });
 });

--- a/services/util/parseWikiUrl.test.js
+++ b/services/util/parseWikiUrl.test.js
@@ -105,7 +105,7 @@ describe('parse()', () => {
     expect(() => parse(url)).toThrow('invalid-url');
   });
 
-  it('throws an expception for invalid urls', () => {
+  it('throws an exception for invalid urls', () => {
     const url = '%';
     expect(() => parse(url)).toThrow('invalid-url');
   });

--- a/services/util/parseWikiUrl.test.js
+++ b/services/util/parseWikiUrl.test.js
@@ -85,23 +85,28 @@ describe('parse()', () => {
     });
   });
 
-  it('throws a 422 exception for for non-wiki url', () => {
+  it('throws an exception for for non-wiki url', () => {
     const url = 'https://en.pokepedia.org/wiki/Lower_Saxony';
-    expect(() => parse(url)).toThrow('badData');
+    expect(() => parse(url)).toThrow('invalid-url');
   });
 
-  it('throws a 422 exception for empty urls', () => {
+  it('throws an exception for empty urls', () => {
     const url = '';
-    expect(() => parse(url)).toThrow('badData');
+    expect(() => parse(url)).toThrow('invalid-url');
   });
 
-  it('throws a 422 exception for null urls', () => {
+  it('throws an exception for null urls', () => {
     const url = null;
-    expect(() => parse(url)).toThrow('badData');
+    expect(() => parse(url)).toThrow('invalid-url');
   });
 
-  it('throws a 422 exception for undefined urls', () => {
+  it('throws an exception for undefined urls', () => {
     const url = undefined;
-    expect(() => parse(url)).toThrow('badData');
+    expect(() => parse(url)).toThrow('invalid-url');
+  });
+
+  it('throws an expception for invalid urls', () => {
+    const url = '%';
+    expect(() => parse(url)).toThrow('invalid-url');
   });
 });


### PR DESCRIPTION
This adds some error handling to the `files` endpoint: if the given article url is invalid (or cannot be parsed) we return a `422` response and if the required Wikipedia / Wikimedia APIs aren't available we return a `503` (_"service unavailable"_) response.

As discussed with @juffel in person, I remove the `error` function from the `server` toolkit and instead wrap and call the respective errors directly by hand in the `routes` definition. Doing so, we can specifically decided which errors we handle for which route and just return anything else as `500` response.

As a drive-by-fix I also update the distinction between public and private api and the error handling and naming in the files I came across while adding the errors for the `files` endpoint.

It might be too much of an effort, but I actually personally don't really like matching the error messages on their `message` string and would rather prefer to match on their **type**. This would of course mean, we'd have to add some custom errors - but I think that's quite simple and fast.
It would allow us to have a specific type of error for e.g. client / wikpedia-api related errors... What do you think?