### PR TITLE
[#21] Extend response of `/files` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,12 @@ It can be useful to run tests with the `DEBUG` flag enabled in order to get more
 DEBUG=true yarn test
 ```
 
+## Resources
+
+The app communicates with the Wikimedia and Wikipedia APIs:
+
+- https://commons.wikimedia.org/w/api.php
+- https://de.wikipedia.org/w/api.php
+- https://en.wikipedia.org/w/api.php
+
 <!-- TODO: Add sections on contribution guidelines…? -->

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18,6 +18,26 @@ definitions:
         type: string
     required:
       - version
+  RawUrlWidthHeightModel:
+    properties:
+      height:
+        type: integer
+      rawUrl:
+        type: string
+      width:
+        type: integer
+  TitleDescriptionUrlRawUrlFileSizeThumbnailModel:
+    properties:
+      descriptionUrl:
+        type: string
+      fileSize:
+        type: integer
+      rawUrl:
+        type: string
+      thumbnail:
+        $ref: '#/definitions/RawUrlWidthHeightModel'
+      title:
+        type: string
   UrlCodeModel:
     properties:
       code:
@@ -63,6 +83,11 @@ paths:
     get:
       description: Retrieve all files for a given article or page url.
       operationId: files.index
+      parameters:
+        - in: path
+          name: articleUrl
+          required: true
+          type: string
       produces:
         - application/json
       responses:
@@ -74,7 +99,7 @@ paths:
           description: ''
           schema:
             items:
-              type: string
+              $ref: '#/definitions/TitleDescriptionUrlRawUrlFileSizeThumbnailModel'
             type: array
       security:
         - default: []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18,6 +18,9 @@ definitions:
         type: string
     required:
       - version
+  InternalServerError:
+    description: Internal Server Error
+    properties: {}
   RawUrlWidthHeightModel:
     properties:
       height:
@@ -26,6 +29,13 @@ definitions:
         type: string
       width:
         type: integer
+    required:
+      - rawUrl
+      - width
+      - height
+  ServiceUnavailableErrorResponse:
+    description: Service Unavailable
+    properties: {}
   TitleDescriptionUrlRawUrlFileSizeThumbnailModel:
     properties:
       descriptionUrl:
@@ -38,6 +48,15 @@ definitions:
         $ref: '#/definitions/RawUrlWidthHeightModel'
       title:
         type: string
+    required:
+      - title
+      - descriptionUrl
+      - rawUrl
+      - fileSize
+      - thumbnail
+  UnprocessableEntityErrorResponse:
+    description: Unprocessable Entity
+    properties: {}
   UrlCodeModel:
     properties:
       code:
@@ -95,6 +114,18 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/BadRequestErrorResponse'
+        '422':
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/UnprocessableEntityErrorResponse'
+        '500':
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+        '503':
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/ServiceUnavailableErrorResponse'
         default:
           description: ''
           schema:

--- a/routes/__snapshots__/files.test.js.snap
+++ b/routes/__snapshots__/files.test.js.snap
@@ -35,8 +35,15 @@ Object {
 exports[`files routes GET /files returns a list of all files from the given article 1`] = `
 Array [
   Object {
-    "file": "File:image.jpg",
-    "url": "https://en.wikipedia.org/wiki/File:image.jpg",
+    "descriptionUrl": "https://commons.wikimedia.org/wiki/File:Graphic_01.jpg",
+    "fileSize": 112450,
+    "rawUrl": "https://upload.wikimedia.org/wikipedia/commons/e/ef/Graphic_01.jpg",
+    "thumbnail": Object {
+      "height": 300,
+      "rawUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Graphic_01.jpg/300px-Graphic_01.jpg",
+      "width": 300,
+    },
+    "title": "File:Graphic 01.jpg",
   },
 ]
 `;

--- a/routes/__snapshots__/files.test.js.snap
+++ b/routes/__snapshots__/files.test.js.snap
@@ -8,6 +8,14 @@ Object {
 }
 `;
 
+exports[`files routes GET /files returns a 400 response for non http(s) urls 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": "Invalid request params input",
+  "statusCode": 400,
+}
+`;
+
 exports[`files routes GET /files returns a 404 when called with an unencoded articleUrl 1`] = `
 Object {
   "error": "Not Found",

--- a/routes/__snapshots__/files.test.js.snap
+++ b/routes/__snapshots__/files.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`files routes GET /files returns 422 response if the URL is invalid 1`] = `
+exports[`files routes GET /files returns 400 response if the URL is invalid 1`] = `
 Object {
-  "error": "Unprocessable Entity",
-  "message": "invalid-url",
-  "statusCode": 422,
+  "error": "Bad Request",
+  "message": "Invalid request params input",
+  "statusCode": 400,
 }
 `;
 
@@ -13,6 +13,14 @@ Object {
   "error": "Not Found",
   "message": "Not Found",
   "statusCode": 404,
+}
+`;
+
+exports[`files routes GET /files returns a 422 response for non-wiki urls 1`] = `
+Object {
+  "error": "Unprocessable Entity",
+  "message": "invalid-url",
+  "statusCode": 422,
 }
 `;
 

--- a/routes/__swagger__/definitions.js
+++ b/routes/__swagger__/definitions.js
@@ -7,6 +7,15 @@ const errors = {
   401: Joi.object()
     .description('Unauthorized')
     .meta({ className: 'UnauthorizedErrorResponse' }),
+  422: Joi.object()
+    .description('Unprocessable Entity')
+    .meta({ className: 'UnprocessableEntityErrorResponse' }),
+  500: Joi.object()
+    .description('Internal Server Error')
+    .meta({ className: 'InternalServerError' }),
+  503: Joi.object()
+    .description('Service Unavailable')
+    .meta({ className: 'ServiceUnavailableErrorResponse' }),
 };
 
 module.exports = { errors };

--- a/routes/files.js
+++ b/routes/files.js
@@ -5,6 +5,18 @@ const definitions = require('./__swagger__/definitions');
 
 const routes = [];
 
+const fileSchema = Joi.object({
+  title: Joi.string(),
+  descriptionUrl: Joi.string().uri(),
+  rawUrl: Joi.string().uri(),
+  fileSize: Joi.number().integer(),
+  thumbnail: Joi.object().keys({
+    rawUrl: Joi.string().uri(),
+    width: Joi.number().integer(),
+    height: Joi.number().integer(),
+  }),
+});
+
 function handleError(h, { message }) {
   switch (message) {
     case errors.invalidUrl:
@@ -22,9 +34,13 @@ routes.push({
   options: {
     description: 'Get all files for an article',
     notes: 'Retrieve all files for a given article or page url.',
-    validate: {},
+    validate: {
+      params: {
+        articleUrl: Joi.string(),
+      },
+    },
     response: {
-      schema: Joi.array(),
+      schema: Joi.array().items(fileSchema),
       status: {
         400: definitions.errors['400'],
       },

--- a/routes/files.js
+++ b/routes/files.js
@@ -6,15 +6,29 @@ const definitions = require('./__swagger__/definitions');
 const routes = [];
 
 const fileSchema = Joi.object({
-  title: Joi.string(),
-  descriptionUrl: Joi.string().uri(),
-  rawUrl: Joi.string().uri(),
-  fileSize: Joi.number().integer(),
-  thumbnail: Joi.object().keys({
-    rawUrl: Joi.string().uri(),
-    width: Joi.number().integer(),
-    height: Joi.number().integer(),
-  }),
+  title: Joi.string().required(),
+  descriptionUrl: Joi.string()
+    .uri()
+    .required(),
+  rawUrl: Joi.string()
+    .uri()
+    .required(),
+  fileSize: Joi.number()
+    .integer()
+    .required(),
+  thumbnail: Joi.object()
+    .required()
+    .keys({
+      rawUrl: Joi.string()
+        .uri()
+        .required(),
+      width: Joi.number()
+        .integer()
+        .required(),
+      height: Joi.number()
+        .integer()
+        .required(),
+    }),
 });
 
 function handleError(h, { message }) {
@@ -36,13 +50,16 @@ routes.push({
     notes: 'Retrieve all files for a given article or page url.',
     validate: {
       params: {
-        articleUrl: Joi.string(),
+        articleUrl: Joi.string().uri(),
       },
     },
     response: {
       schema: Joi.array().items(fileSchema),
       status: {
         400: definitions.errors['400'],
+        422: definitions.errors['422'],
+        500: definitions.errors['500'],
+        503: definitions.errors['503'],
       },
     },
     plugins: {

--- a/routes/files.js
+++ b/routes/files.js
@@ -50,7 +50,7 @@ routes.push({
     notes: 'Retrieve all files for a given article or page url.',
     validate: {
       params: {
-        articleUrl: Joi.string().uri(),
+        articleUrl: Joi.string().uri({ scheme: ['http', 'https'] }),
       },
     },
     response: {

--- a/routes/files.test.js
+++ b/routes/files.test.js
@@ -51,6 +51,17 @@ describe('files routes', () => {
       expect(response.payload).toMatchSnapshot();
     });
 
+    it('returns a 400 response for non http(s) urls', async () => {
+      const sftpUrl = 'sftp://en.wikipedia.org/wiki/Wikimedia_Foundation';
+      const encodedSftpUrl = encodeURIComponent(sftpUrl);
+      const response = await subject({ url: `/files/${encodedSftpUrl}` });
+
+      expect(files.getPageImages).not.toHaveBeenCalled();
+      expect(response.status).toBe(400);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
+
     it('returns 400 response if the URL is invalid', async () => {
       const response = await subject({ url: '/files/something-invalid' });
 

--- a/routes/files.test.js
+++ b/routes/files.test.js
@@ -6,7 +6,18 @@ describe('files routes', () => {
   const files = { getPageImages: jest.fn() };
   const services = { files };
   const filesMock = [
-    { file: 'File:image.jpg', url: 'https://en.wikipedia.org/wiki/File:image.jpg' },
+    {
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Graphic_01.jpg',
+      fileSize: 112450,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/ef/Graphic_01.jpg',
+      thumbnail: {
+        height: 300,
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Graphic_01.jpg/300px-Graphic_01.jpg',
+        width: 300,
+      },
+      title: 'File:Graphic 01.jpg',
+    },
   ];
 
   let context;

--- a/services/__fixtures__/imagesInfo.js
+++ b/services/__fixtures__/imagesInfo.js
@@ -8,6 +8,13 @@ module.exports = {
       imagerepository: 'shared',
       imageinfo: [
         {
+          size: 112450,
+          width: 700,
+          height: 701,
+          thumburl:
+            'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Graphic_01.jpg/300px-Graphic_01.jpg',
+          thumbwidth: 300,
+          thumbheight: 300,
           url: 'https://upload.wikimedia.org/wikipedia/commons/e/ef/Graphic_01.jpg',
           descriptionurl: 'https://commons.wikimedia.org/wiki/File:Graphic_01.jpg',
           descriptionshorturl: 'https://commons.wikimedia.org/w/index.php?curid=1720256',
@@ -22,6 +29,13 @@ module.exports = {
       imagerepository: 'shared',
       imageinfo: [
         {
+          size: 112450,
+          width: 700,
+          height: 701,
+          thumburl:
+            'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/logo.svg/300px-logo.svg',
+          thumbwidth: 300,
+          thumbheight: 300,
           url: 'https://upload.wikimedia.org/wikipedia/commons/4/4a/logo.svg',
           descriptionurl: 'https://commons.wikimedia.org/wiki/File:logo.svg',
           descriptionshorturl: 'https://commons.wikimedia.org/w/index.php?curid=317966',

--- a/services/__snapshots__/files.test.js.snap
+++ b/services/__snapshots__/files.test.js.snap
@@ -3,12 +3,26 @@
 exports[`Files getPageImages() with a valid wikipedia url returns a list of all images from the given article 1`] = `
 Array [
   Object {
+    "descriptionUrl": "https://commons.wikimedia.org/wiki/File:Graphic_01.jpg",
+    "fileSize": 112450,
+    "rawUrl": "https://upload.wikimedia.org/wikipedia/commons/e/ef/Graphic_01.jpg",
+    "thumbnail": Object {
+      "height": 300,
+      "rawUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Graphic_01.jpg/300px-Graphic_01.jpg",
+      "width": 300,
+    },
     "title": "File:Graphic 01.jpg",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/e/ef/Graphic_01.jpg",
   },
   Object {
+    "descriptionUrl": "https://commons.wikimedia.org/wiki/File:logo.svg",
+    "fileSize": 112450,
+    "rawUrl": "https://upload.wikimedia.org/wikipedia/commons/4/4a/logo.svg",
+    "thumbnail": Object {
+      "height": 300,
+      "rawUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/logo.svg/300px-logo.svg",
+      "width": 300,
+    },
     "title": "File:logo.svg",
-    "url": "https://upload.wikimedia.org/wikipedia/commons/4/4a/logo.svg",
   },
 ]
 `;

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -29,7 +29,7 @@ function parseIdentifier(identifier) {
 
 async function getImageInfo({ client, title, wikiUrl }) {
   const params = { iiprop: 'url|extmetadata', iilimit: 1, iiurlheight: 300 };
-  const response = await client.getResultsFromApi(title, 'imageinfo', wikiUrl, params);
+  const response = await client.getResultsFromApi([title], 'imageinfo', wikiUrl, params);
   return parseImageInfoResponse(response);
 }
 

--- a/services/fileData.test.js
+++ b/services/fileData.test.js
@@ -23,7 +23,7 @@ describe('FileData', () => {
         const fileData = await service.getFileData(url);
 
         expect(client.getResultsFromApi).toHaveBeenCalledWith(
-          'File:Apple_Lisa.jpg',
+          ['File:Apple_Lisa.jpg'],
           'imageinfo',
           'https://en.wikipedia.org/',
           {
@@ -60,7 +60,7 @@ describe('FileData', () => {
         const service = new FileData({ client });
         const fileData = await service.getFileData(title);
 
-        expect(client.getResultsFromApi).toHaveBeenCalledWith(title, 'imageinfo', wikiUrl, {
+        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'imageinfo', wikiUrl, {
           iiprop: 'url|extmetadata',
           iilimit: 1,
           iiurlheight: 300,

--- a/services/files.integration.test.js
+++ b/services/files.integration.test.js
@@ -11,20 +11,53 @@ describe('getPageImages()', () => {
   const expectedFiles = [
     {
       title: 'Datei:Backyard babies 02.jpg',
-      url: 'https://upload.wikimedia.org/wikipedia/commons/e/ef/Backyard_babies_02.jpg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Backyard_babies_02.jpg',
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/ef/Backyard_babies_02.jpg',
+      fileSize: 112450,
+      thumbnail: {
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Backyard_babies_02.jpg/300px-Backyard_babies_02.jpg',
+        width: 300,
+        height: 300,
+      },
     },
     {
       title: 'Datei:Commons-logo.svg',
-      url: 'https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Commons-logo.svg',
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg',
+      fileSize: 932,
+      thumbnail: {
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png',
+        width: 300,
+        height: 403,
+      },
     },
     {
       title: 'Datei:ImperialStateElectric Sonisphere2010.jpg',
-      url:
+      descriptionUrl:
+        'https://commons.wikimedia.org/wiki/File:ImperialStateElectric_Sonisphere2010.jpg',
+      rawUrl:
         'https://upload.wikimedia.org/wikipedia/commons/8/86/ImperialStateElectric_Sonisphere2010.jpg',
+      fileSize: 1168631,
+      thumbnail: {
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/8/86/ImperialStateElectric_Sonisphere2010.jpg/300px-ImperialStateElectric_Sonisphere2010.jpg',
+        width: 300,
+        height: 225,
+      },
     },
     {
       title: 'Datei:Nick royale and strings.jpg',
-      url: 'https://upload.wikimedia.org/wikipedia/commons/7/7b/Nick_royale_and_strings.jpg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Nick_royale_and_strings.jpg',
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/7/7b/Nick_royale_and_strings.jpg',
+      fileSize: 3068651,
+      thumbnail: {
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Nick_royale_and_strings.jpg/300px-Nick_royale_and_strings.jpg',
+        width: 300,
+        height: 199,
+      },
     },
   ];
 

--- a/services/files.js
+++ b/services/files.js
@@ -4,7 +4,7 @@ const parseWikiUrl = require('./util/parseWikiUrl');
 const errors = require('./util/errors');
 
 async function getImageTitles({ client, title, wikiUrl }) {
-  const response = await client.getResultsFromApi(title, 'images', wikiUrl);
+  const response = await client.getResultsFromApi([title], 'images', wikiUrl);
   assert.ok(response.pages, errors.emptyResponse);
   const pages = Object.values(response.pages);
   assert.ok(pages.length === 1);
@@ -30,8 +30,7 @@ function formatImageInfo(page) {
 
 async function getImageUrls({ client, titles, wikiUrl }) {
   const params = { iiprop: 'url|size', iiurlwidth: 300 };
-  const title = titles.join('|');
-  const { pages } = await client.getResultsFromApi(title, 'imageinfo', wikiUrl, params);
+  const { pages } = await client.getResultsFromApi(titles, 'imageinfo', wikiUrl, params);
   assert.ok(pages, errors.emptyResponse);
 
   return Object.values(pages).map(formatImageInfo);

--- a/services/files.js
+++ b/services/files.js
@@ -15,13 +15,21 @@ async function getImageTitles({ client, title, wikiUrl }) {
 
 function formatImageInfo(page) {
   const { title, imageinfo } = page;
-  const { url } = imageinfo[0];
+  const {
+    url: rawUrl,
+    descriptionurl: descriptionUrl,
+    size: fileSize,
+    thumburl,
+    thumbwidth,
+    thumbheight,
+  } = imageinfo[0];
+  const thumbnail = { rawUrl: thumburl, width: thumbwidth, height: thumbheight };
 
-  return { title, url };
+  return { title, descriptionUrl, rawUrl, fileSize, thumbnail };
 }
 
 async function getImageUrls({ client, titles, wikiUrl }) {
-  const params = { iiprop: 'url' };
+  const params = { iiprop: 'url|size', iiurlwidth: 300 };
   const title = titles.join('|');
   const { pages } = await client.getResultsFromApi(title, 'imageinfo', wikiUrl, params);
   assert.ok(pages, errors.emptyResponse);

--- a/services/files.test.js
+++ b/services/files.test.js
@@ -41,7 +41,7 @@ describe('Files', () => {
           'File:Graphic 01.jpg|File:logo.svg',
           'imageinfo',
           wikiUrl,
-          { iiprop: 'url' }
+          { iiprop: 'url|size', iiurlwidth: 300 }
         );
         expect(files).toMatchSnapshot();
       });
@@ -69,7 +69,7 @@ describe('Files', () => {
           'File:Graphic 01.jpg|File:logo.svg',
           'imageinfo',
           wikiUrl,
-          { iiprop: 'url' }
+          { iiprop: 'url|size', iiurlwidth: 300 }
         );
         expect(files).toEqual([]);
       });

--- a/services/files.test.js
+++ b/services/files.test.js
@@ -36,9 +36,9 @@ describe('Files', () => {
         const service = new Files({ client });
         const files = await service.getPageImages(url);
 
-        expect(client.getResultsFromApi).toHaveBeenCalledWith(title, 'images', wikiUrl);
+        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl);
         expect(client.getResultsFromApi).toHaveBeenCalledWith(
-          'File:Graphic 01.jpg|File:logo.svg',
+          ['File:Graphic 01.jpg', 'File:logo.svg'],
           'imageinfo',
           wikiUrl,
           { iiprop: 'url|size', iiurlwidth: 300 }
@@ -52,7 +52,7 @@ describe('Files', () => {
         const service = new Files({ client });
         const files = await service.getPageImages(url);
 
-        expect(client.getResultsFromApi).toHaveBeenCalledWith(title, 'images', wikiUrl);
+        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl);
         expect(files).toEqual([]);
       });
 
@@ -64,9 +64,9 @@ describe('Files', () => {
         const service = new Files({ client });
         const files = await service.getPageImages(url);
 
-        expect(client.getResultsFromApi).toHaveBeenCalledWith(title, 'images', wikiUrl);
+        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl);
         expect(client.getResultsFromApi).toHaveBeenCalledWith(
-          'File:Graphic 01.jpg|File:logo.svg',
+          ['File:Graphic 01.jpg', 'File:logo.svg'],
           'imageinfo',
           wikiUrl,
           { iiprop: 'url|size', iiurlwidth: 300 }

--- a/services/licenses.js
+++ b/services/licenses.js
@@ -17,7 +17,7 @@ function formatPageTemplateTitles(response) {
 
 async function getPageTemplates({ client, title, wikiUrl }) {
   const params = { tlnamespace: 10, tllimit: 100 };
-  const response = await client.getResultsFromApi(title, 'templates', wikiUrl, params);
+  const response = await client.getResultsFromApi([title], 'templates', wikiUrl, params);
   return formatPageTemplateTitles(response);
 }
 

--- a/services/licenses.test.js
+++ b/services/licenses.test.js
@@ -35,7 +35,7 @@ describe('Licenses', () => {
 
       const license = await service.getLicense({ title, wikiUrl });
 
-      expect(client.getResultsFromApi).toHaveBeenCalledWith(title, 'templates', wikiUrl, {
+      expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'templates', wikiUrl, {
         tlnamespace: 10,
         tllimit: 100,
       });

--- a/services/util/client.js
+++ b/services/util/client.js
@@ -41,10 +41,11 @@ class Client {
 
   getResultsFromApi(titles, prop, wikiUrl, params = {}) {
     const { client } = this;
+    const titleString = titles.join('|');
     const queryParams = {
       ...defaultParams,
       ...params,
-      titles,
+      titles: titleString,
       prop,
     };
     return queryApi({ client, wikiUrl, params: queryParams });

--- a/services/util/client.test.js
+++ b/services/util/client.test.js
@@ -31,7 +31,7 @@ describe('Client', () => {
     const mockedResponse = { data: { query: { foo: 'bar' } } };
 
     it('returns an error if the API cannot be reached', async () => {
-      const titles = 'Def_Leppard';
+      const titles = ['Def_Leppard'];
       const error = { request: {} };
       axiosClient.get.mockImplementation(() => {
         throw error;
@@ -44,7 +44,7 @@ describe('Client', () => {
     });
 
     it('passes on any errors from doing the request', async () => {
-      const titles = 'Def_Leppard';
+      const titles = ['Def_Leppard'];
       axiosClient.get.mockImplementation(() => {
         throw new Error();
       });
@@ -54,9 +54,10 @@ describe('Client', () => {
     });
 
     it('allows querying for images of a page', async () => {
-      const titles = 'Def_Leppard';
+      const titleString = 'Def_Leppard';
+      const titles = [titleString];
       const prop = 'image';
-      const params = { ...defaultParams, prop, titles };
+      const params = { ...defaultParams, prop, titles: titleString };
 
       axiosClient.get.mockResolvedValue(mockedResponse);
 
@@ -68,9 +69,10 @@ describe('Client', () => {
     });
 
     it('allows querying for multiple titles with additional params', async () => {
-      const titles = 'File:Steve_Clark.jpeg|File:RickAllen.JPG';
+      const titles = ['File:Steve_Clark.jpeg', 'File:RickAllen.JPG'];
+      const titleString = 'File:Steve_Clark.jpeg|File:RickAllen.JPG';
       const prop = 'imageInfo';
-      const params = { ...defaultParams, prop, titles, iiprop: 'url' };
+      const params = { ...defaultParams, prop, titles: titleString, iiprop: 'url' };
 
       axiosClient.get.mockResolvedValue(mockedResponse);
 

--- a/services/util/parseWikiUrl.js
+++ b/services/util/parseWikiUrl.js
@@ -42,7 +42,7 @@ function splitWikipediaUrl(url) {
   return { title, wikiUrl };
 }
 
-function splitUrl(url) {
+function parse(url) {
   if (uploadRegExp.test(url)) {
     return splitUploadUrl(url);
   }
@@ -50,16 +50,6 @@ function splitUrl(url) {
     return splitWikipediaUrl(url);
   }
   throw new Error(errors.invalidUrl);
-}
-
-function parse(url) {
-  try {
-    const sanitizedUrl = decodeURI(url);
-    return splitUrl(sanitizedUrl);
-  } catch (error) {
-    if (error instanceof URIError) throw new Error(errors.invalidUrl);
-    throw error;
-  }
 }
 
 module.exports = parse;


### PR DESCRIPTION
This updates the response of the `/files` endpoint to include more information (see the API docs for reference) as specified in [this ticket](https://ora.pm/project/59434/kanban/task/732217).

I'm not 100% sure about the params validation in the route yet. We could in theory enforce it to be a url and respond with `400` otherwise - which would spare handling this within our business logic. I'm also only 90% sure about specifying the response schema: what things should be marked as required 🤔 