### PR TITLE
[#29] Adapt /licenses/compatible

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -63,6 +63,9 @@ definitions:
         type: string
       url:
         type: string
+    required:
+      - url
+      - code
 host: TODO
 info:
   description: Create attribution hints for images from Wikipedia and Wikimedia Commons.
@@ -184,12 +187,12 @@ paths:
       summary: Licenses index
       tags:
         - licenses
-  '/licenses/compatible/{license}':
+  '/licenses/compatible/{licenseId}':
     get:
-      description: Returns a list of licenses that are compatible to the passed license
+      description: Returns a list of licenses that are compatible to the passed license ID
       parameters:
         - in: path
-          name: license
+          name: licenseId
           required: true
           type: string
       produces:

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -64,3 +64,5 @@ Array [
   },
 ]
 `;
+
+exports[`license routes GET /licenses/compatible/{license} returns an empty response if no compatible licences could be found 1`] = `Array []`;

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -5,8 +5,10 @@ const errors = require('../services/util/errors');
 const routes = [];
 
 const licenseSchema = Joi.object({
-  url: Joi.string().uri(),
-  code: Joi.string(),
+  url: Joi.string()
+    .uri()
+    .required(),
+  code: Joi.string().required(),
 });
 
 function handleError(h, { message }) {
@@ -23,14 +25,14 @@ function handleError(h, { message }) {
 }
 
 routes.push({
-  path: '/licenses/compatible/{license}',
+  path: '/licenses/compatible/{licenseId}',
   method: 'GET',
   options: {
     description: 'Compatible licenses',
-    notes: 'Returns a list of licenses that are compatible to the passed license',
+    notes: 'Returns a list of licenses that are compatible to the passed license ID',
     validate: {
       params: {
-        license: Joi.string(),
+        licenseId: Joi.string(),
       },
     },
     response: {
@@ -39,8 +41,8 @@ routes.push({
   },
   handler: async (request, h) => {
     const { licenseStore } = request.server.app.services;
-    const param = decodeURIComponent(request.params.license).replace(/\+/g, ' ');
-    const licenses = licenseStore.compatible(param);
+    const { licenseId } = request.params;
+    const licenses = licenseStore.compatible(licenseId);
     const response = licenses.map(({ url, name }) => ({ url: encodeURI(url), code: name }));
     return h.response(response);
   },

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -23,6 +23,8 @@ describe('license routes', () => {
   beforeEach(async () => {
     fileData.getFileData.mockReset();
     licenses.getLicense.mockReset();
+    licenseStore.all.mockReset();
+    licenseStore.compatible.mockReset();
     context = await setup({ services });
   });
 
@@ -53,30 +55,33 @@ describe('license routes', () => {
   });
 
   describe('GET /licenses/compatible/{license}', () => {
+    const licenseId = 'cc-by-sa-3.0-de';
     function options() {
-      return { url: `/licenses/compatible/CC+BY-SA+3.0`, method: 'GET' };
+      return { url: `/licenses/compatible/${licenseId}`, method: 'GET' };
     }
 
     async function subject() {
       return context.inject(options());
     }
 
-    beforeEach(() => {
-      licenseStore.compatible.mockReturnValue(licensesMock);
-    });
-
     it('returns a list of licenses', async () => {
+      licenseStore.compatible.mockReturnValue(licensesMock);
       const response = await subject();
 
+      expect(licenseStore.compatible).toHaveBeenCalledWith(licenseId);
       expect(response.status).toBe(200);
       expect(response.type).toBe('application/json');
       expect(response.payload).toMatchSnapshot();
     });
 
-    it('calls service with decoded license parameter string', async () => {
-      await subject();
+    it('returns an empty response if no compatible licences could be found', async () => {
+      licenseStore.compatible.mockReturnValue([]);
+      const response = await subject();
 
-      expect(licenseStore.compatible).toHaveBeenCalledWith('CC BY-SA 3.0');
+      expect(licenseStore.compatible).toHaveBeenCalledWith(licenseId);
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
     });
   });
 

--- a/services/licenseStore.js
+++ b/services/licenseStore.js
@@ -79,9 +79,9 @@ class LicenseStore {
     return this.licenses.filter(({ name, url }) => !!name && !!url);
   }
 
-  // Returns all compatible licenses for the passed license name.
-  compatible(name) {
-    const license = this.getLicenseByName(name);
+  // Returns all compatible licenses for the passed license id.
+  compatible(id) {
+    const license = this.getLicenseById(id);
     if (license) {
       const { compatibility } = license;
       return compatibility.map(cid => this.getLicenseById(cid));

--- a/services/licenseStore.test.js
+++ b/services/licenseStore.test.js
@@ -130,24 +130,29 @@ describe('licenseStore', () => {
     const expectedKeys = ['id', 'name', 'groups', 'compatibility', 'regexp', 'url'];
 
     it('returns an array of licenses', () => {
-      const compatible = subject.compatible('CC BY-SA 3.0');
+      const compatible = subject.compatible('cc-by-sa-3.0');
       compatible.forEach(license => {
         expect(Object.keys(license)).toEqual(expectedKeys);
       });
     });
 
-    it('finds compatible licenses for "CC BY-SA 3.0"', () => {
-      const compatible = subject.compatible('CC BY-SA 3.0');
+    it('finds compatible licenses for "cc-by-sa-3.0"', () => {
+      const compatible = subject.compatible('cc-by-sa-3.0');
       expect(compatible.map(license => license.id)).toEqual(['cc-by-sa-3.0-de', 'cc-by-sa-4.0']);
     });
 
-    it('finds no compatible licences for "CC BY-SA 4.0"', () => {
-      const compatible = subject.compatible('CC BY-SA 4.0');
+    it('finds compatible licenses for "cc-by-sa-4.0"', () => {
+      const compatible = subject.compatible('cc-by-sa-4.0');
       expect(compatible).toEqual([]);
     });
 
-    it('finds no compatible license for invalid license name', () => {
-      const compatible = subject.compatible('XX BY-SA 3.0');
+    it('finds no compatible license for an invalid license id', () => {
+      const compatible = subject.compatible('xx-by-sa-3.0');
+      expect(compatible).toEqual([]);
+    });
+
+    it('finds no compatible license for ported licenes', () => {
+      const compatible = subject.compatible('cc-by-sa-3.0-ported');
       expect(compatible).toEqual([]);
     });
 
@@ -155,8 +160,8 @@ describe('licenseStore', () => {
       const expected = compatibleCases[id];
       const license = subject.getLicenseById(id);
 
-      it(`finds compatible licenses for "${license.name}"`, () => {
-        const compatible = subject.compatible(license.name);
+      it(`finds compatible licenses for "${license.id}"`, () => {
+        const compatible = subject.compatible(license.id);
         expect(compatible).toHaveLength(expected.length);
         const ids = compatible.map(l => l.id);
         expect(ids).toEqual(expect.arrayContaining(expected));


### PR DESCRIPTION
This adapts the `license/compatible` endpoint as specified in [this ticket](https://ora.pm/project/59434/kanban/task/732311): instead of taking the license **name**, we're now expecting an **ID**. Otherwise we cannot distinguish between ported and "normal" licenses...

Do do so, I also adapted the `compatible` function in the `LicenseStore` to use the ID rather then the name of the license. The result of this - without any additional logic - is that for most ported licenses, the endpoint does not return anything.