### PR TITLE
[#27] Extend result of license API calls

### DIFF
--- a/__helpers__/licenseFactory.js
+++ b/__helpers__/licenseFactory.js
@@ -1,0 +1,12 @@
+function licenseFactory({ id, name, url, groups, compatibility, regexp }) {
+  return {
+    id: id || 'cc-by-sa-3.0',
+    name: name || 'CC BY-SA 3.0',
+    groups: groups || ['cc', 'cc4'],
+    compatibility: compatibility || [],
+    regexp: regexp || /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
+    url: url || 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
+  };
+}
+
+module.exports = licenseFactory;

--- a/__helpers__/licenseFactory.js
+++ b/__helpers__/licenseFactory.js
@@ -1,12 +1,14 @@
-function licenseFactory({ id, name, url, groups, compatibility, regexp }) {
-  return {
-    id: id || 'cc-by-sa-3.0',
-    name: name || 'CC BY-SA 3.0',
-    groups: groups || ['cc', 'cc4'],
-    compatibility: compatibility || [],
-    regexp: regexp || /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
-    url: url || 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
-  };
+const License = require('../models/license');
+
+function licenseFactory({
+  id = 'cc-by-sa-3.0',
+  name = 'CC BY-SA 3.0',
+  groups = ['cc', 'cc4'],
+  compatibility = [],
+  regexp = /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
+  url = 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
+}) {
+  return new License({ id, name, url, groups, compatibility, regexp });
 }
 
 module.exports = licenseFactory;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,12 +4,23 @@ definitions:
   BadRequestErrorResponse:
     description: Bad Request
     properties: {}
-  CodeUrlModel:
+  CodeNameUrlGroupsModel:
     properties:
       code:
         type: string
+      groups:
+        items:
+          type: string
+        type: array
+      name:
+        type: string
       url:
         type: string
+    required:
+      - code
+      - name
+      - url
+      - groups
   InfoShowResponse:
     properties:
       version:
@@ -57,15 +68,6 @@ definitions:
   UnprocessableEntityErrorResponse:
     description: Unprocessable Entity
     properties: {}
-  UrlCodeModel:
-    properties:
-      code:
-        type: string
-      url:
-        type: string
-    required:
-      - url
-      - code
 host: TODO
 info:
   description: Create attribution hints for images from Wikipedia and Wikimedia Commons.
@@ -168,7 +170,7 @@ paths:
         default:
           description: ''
           schema:
-            $ref: '#/definitions/CodeUrlModel'
+            $ref: '#/definitions/CodeNameUrlGroupsModel'
       summary: Image license
       tags:
         - license
@@ -182,7 +184,7 @@ paths:
           description: ''
           schema:
             items:
-              $ref: '#/definitions/UrlCodeModel'
+              $ref: '#/definitions/CodeNameUrlGroupsModel'
             type: array
       summary: Licenses index
       tags:
@@ -202,7 +204,7 @@ paths:
           description: ''
           schema:
             items:
-              $ref: '#/definitions/UrlCodeModel'
+              $ref: '#/definitions/CodeNameUrlGroupsModel'
             type: array
       summary: Compatible licenses
       tags:

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -40,7 +40,7 @@ Object {
     "cc4",
   ],
   "name": "CC BY-SA 4.0",
-  "url": "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
+  "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
 }
 `;
 
@@ -53,7 +53,7 @@ Array [
       "cc4",
     ],
     "name": "CC BY-SA 4.0",
-    "url": "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
+    "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
   },
   Object {
     "code": "cc-by-sa-3.0",
@@ -76,7 +76,7 @@ Array [
       "cc4",
     ],
     "name": "CC BY-SA 4.0",
-    "url": "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
+    "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
   },
   Object {
     "code": "cc-by-sa-3.0",

--- a/routes/__snapshots__/licenses.test.js.snap
+++ b/routes/__snapshots__/licenses.test.js.snap
@@ -34,20 +34,35 @@ Object {
 
 exports[`license routes GET /license returns the license of a file 1`] = `
 Object {
-  "code": "CC BY-SA 3.0",
-  "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
+  "code": "cc-by-sa-4.0",
+  "groups": Array [
+    "cc",
+    "cc4",
+  ],
+  "name": "CC BY-SA 4.0",
+  "url": "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
 }
 `;
 
 exports[`license routes GET /licenses returns a list of licenses 1`] = `
 Array [
   Object {
-    "code": "bar",
-    "url": "https://foo.bar/path%20with%20spaces",
+    "code": "cc-by-sa-4.0",
+    "groups": Array [
+      "cc",
+      "cc4",
+    ],
+    "name": "CC BY-SA 4.0",
+    "url": "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
   },
   Object {
-    "code": "foo",
-    "url": "https://foo.bar/just-a-regular-path",
+    "code": "cc-by-sa-3.0",
+    "groups": Array [
+      "cc",
+      "cc4",
+    ],
+    "name": "CC BY-SA 3.0",
+    "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
   },
 ]
 `;
@@ -55,12 +70,22 @@ Array [
 exports[`license routes GET /licenses/compatible/{license} returns a list of licenses 1`] = `
 Array [
   Object {
-    "code": "bar",
-    "url": "https://foo.bar/path%20with%20spaces",
+    "code": "cc-by-sa-4.0",
+    "groups": Array [
+      "cc",
+      "cc4",
+    ],
+    "name": "CC BY-SA 4.0",
+    "url": "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
   },
   Object {
-    "code": "foo",
-    "url": "https://foo.bar/just-a-regular-path",
+    "code": "cc-by-sa-3.0",
+    "groups": Array [
+      "cc",
+      "cc4",
+    ],
+    "name": "CC BY-SA 3.0",
+    "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
   },
 ]
 `;

--- a/routes/licenses.integration.test.js
+++ b/routes/licenses.integration.test.js
@@ -47,8 +47,10 @@ describe('license routes', () => {
       expect(response.status).toBe(200);
       expect(response.type).toBe('application/json');
       expect(response.payload).toMatchObject({
-        code: 'CC BY-SA 2.0 FR',
+        code: 'cc-by-sa-2.0-ported',
+        name: 'CC BY-SA 2.0 FR',
         url: 'https://creativecommons.org/licenses/by-sa/2.0/fr/deed.en',
+        groups: ['cc', 'cc2', 'ported', 'knownPorted'],
       });
     });
   });

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -4,6 +4,11 @@ const errors = require('../services/util/errors');
 
 const routes = [];
 
+function serialize(license) {
+  const { id: code, name, url, groups } = license;
+  return { code, name, url, groups };
+}
+
 const licenseSchema = Joi.object({
   code: Joi.string().required(),
   name: Joi.string().required(),
@@ -47,12 +52,7 @@ routes.push({
     const { licenseStore } = request.server.app.services;
     const { licenseId } = request.params;
     const licenses = licenseStore.compatible(licenseId);
-    const response = licenses.map(({ id: code, url, name, groups }) => ({
-      code,
-      name,
-      url,
-      groups,
-    }));
+    const response = licenses.map(serialize);
     return h.response(response);
   },
 });
@@ -71,12 +71,7 @@ routes.push({
   handler: async (request, h) => {
     const { licenseStore } = request.server.app.services;
     const licenses = licenseStore.all();
-    const response = licenses.map(({ id: code, url, name, groups }) => ({
-      code,
-      name,
-      url,
-      groups,
-    }));
+    const response = licenses.map(serialize);
     return h.response(response);
   },
 });
@@ -102,8 +97,7 @@ routes.push({
     try {
       const { title, wikiUrl } = await fileData.getFileData(fileUrlOrTitle);
       const license = await licenses.getLicense({ title, wikiUrl });
-      const { id: code, name, url, groups } = license;
-      const response = { code, name, url, groups };
+      const response = serialize(license);
       return h.response(response);
     } catch (error) {
       return handleError(h, error);

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -5,10 +5,14 @@ const errors = require('../services/util/errors');
 const routes = [];
 
 const licenseSchema = Joi.object({
+  code: Joi.string().required(),
+  name: Joi.string().required(),
   url: Joi.string()
     .uri()
     .required(),
-  code: Joi.string().required(),
+  groups: Joi.array()
+    .required()
+    .items(Joi.string()),
 });
 
 function handleError(h, { message }) {
@@ -43,7 +47,12 @@ routes.push({
     const { licenseStore } = request.server.app.services;
     const { licenseId } = request.params;
     const licenses = licenseStore.compatible(licenseId);
-    const response = licenses.map(({ url, name }) => ({ url: encodeURI(url), code: name }));
+    const response = licenses.map(({ id: code, url, name, groups }) => ({
+      code,
+      name,
+      url,
+      groups,
+    }));
     return h.response(response);
   },
 });
@@ -62,7 +71,12 @@ routes.push({
   handler: async (request, h) => {
     const { licenseStore } = request.server.app.services;
     const licenses = licenseStore.all();
-    const response = licenses.map(({ url, name }) => ({ url: encodeURI(url), code: name }));
+    const response = licenses.map(({ id: code, url, name, groups }) => ({
+      code,
+      name,
+      url,
+      groups,
+    }));
     return h.response(response);
   },
 });
@@ -79,10 +93,7 @@ routes.push({
       },
     },
     response: {
-      schema: Joi.object().keys({
-        code: Joi.string(),
-        url: Joi.string(),
-      }),
+      schema: licenseSchema,
     },
   },
   handler: async (request, h) => {
@@ -91,7 +102,8 @@ routes.push({
     try {
       const { title, wikiUrl } = await fileData.getFileData(fileUrlOrTitle);
       const license = await licenses.getLicense({ title, wikiUrl });
-      const response = { url: encodeURI(license.url), code: license.name };
+      const { id: code, name, url, groups } = license;
+      const response = { code, name, url, groups };
       return h.response(response);
     } catch (error) {
       return handleError(h, error);

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -1,13 +1,9 @@
 const Joi = require('joi');
 
 const errors = require('../services/util/errors');
+const { license: serialize } = require('../services/util/serializers');
 
 const routes = [];
-
-function serialize(license) {
-  const { id: code, name, url, groups } = license;
-  return { code, name, url, groups };
-}
 
 const licenseSchema = Joi.object({
   code: Joi.string().required(),

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -1,6 +1,7 @@
 const setup = require('./__helpers__/setup');
 
 const errors = require('../services/util/errors');
+const licenseFactory = require('../__helpers__/licenseFactory');
 
 describe('license routes', () => {
   let context;
@@ -10,22 +11,8 @@ describe('license routes', () => {
   const licenses = { getLicense: jest.fn() };
   const services = { licenseStore, fileData, licenses };
   const licensesMock = [
-    {
-      id: 'cc-by-sa-4.0',
-      name: 'CC BY-SA 4.0',
-      groups: ['cc', 'cc4'],
-      compatibility: [],
-      regexp: /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
-      url: 'https://creativecommons.org/licenses/by-sa/4.0/legalcode',
-    },
-    {
-      id: 'cc-by-sa-3.0',
-      name: 'CC BY-SA 3.0',
-      groups: ['cc', 'cc4'],
-      compatibility: [],
-      regexp: /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
-      url: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
-    },
+    licenseFactory({ id: 'cc-by-sa-4.0', name: 'CC BY-SA 4.0' }),
+    licenseFactory({ id: 'cc-by-sa-3.0', name: 'CC BY-SA 3.0' }),
   ];
 
   beforeEach(async () => {
@@ -96,14 +83,7 @@ describe('license routes', () => {
   describe('GET /license', () => {
     const title = 'File:Apple_Lisa2-IMG_1517.jpg';
     const wikiUrl = 'https://en.wikipedia.org';
-    const license = {
-      id: 'cc-by-sa-4.0',
-      name: 'CC BY-SA 4.0',
-      groups: ['cc', 'cc4'],
-      compatibility: [],
-      regexp: /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
-      url: 'https://creativecommons.org/licenses/by-sa/4.0/legalcode',
-    };
+    const license = licenseFactory({ id: 'cc-by-sa-4.0', name: 'CC BY-SA 4.0' });
 
     function options() {
       return { url: `/license/${title}`, method: 'GET' };

--- a/routes/licenses.test.js
+++ b/routes/licenses.test.js
@@ -11,12 +11,20 @@ describe('license routes', () => {
   const services = { licenseStore, fileData, licenses };
   const licensesMock = [
     {
-      url: 'https://foo.bar/path with spaces',
-      name: 'bar',
+      id: 'cc-by-sa-4.0',
+      name: 'CC BY-SA 4.0',
+      groups: ['cc', 'cc4'],
+      compatibility: [],
+      regexp: /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
+      url: 'https://creativecommons.org/licenses/by-sa/4.0/legalcode',
     },
     {
-      url: 'https://foo.bar/just-a-regular-path',
-      name: 'foo',
+      id: 'cc-by-sa-3.0',
+      name: 'CC BY-SA 3.0',
+      groups: ['cc', 'cc4'],
+      compatibility: [],
+      regexp: /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
+      url: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
     },
   ];
 
@@ -89,9 +97,12 @@ describe('license routes', () => {
     const title = 'File:Apple_Lisa2-IMG_1517.jpg';
     const wikiUrl = 'https://en.wikipedia.org';
     const license = {
-      id: 'cc-by-sa-3.0',
-      name: 'CC BY-SA 3.0',
-      url: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
+      id: 'cc-by-sa-4.0',
+      name: 'CC BY-SA 4.0',
+      groups: ['cc', 'cc4'],
+      compatibility: [],
+      regexp: /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
+      url: 'https://creativecommons.org/licenses/by-sa/4.0/legalcode',
     };
 
     function options() {

--- a/services/util/serializers.js
+++ b/services/util/serializers.js
@@ -1,0 +1,6 @@
+function license(licenseObject) {
+  const { id: code, name, url, groups } = licenseObject;
+  return { code, name, url, groups };
+}
+
+module.exports = { license };

--- a/services/util/serializers.test.js
+++ b/services/util/serializers.test.js
@@ -1,0 +1,33 @@
+const serializers = require('./serializers');
+
+describe('license()', () => {
+  const { license: serialize } = serializers;
+  const license = {
+    id: 'cc-by-sa-4.0',
+    name: 'CC BY-SA 4.0',
+    groups: ['cc', 'cc4'],
+    compatibility: [],
+    regexp: /ab+c/,
+    url: 'https://example.org/licenses/by-sa/4.0',
+  };
+
+  it('serializes a license object into the specified format', () => {
+    const serialized = serialize(license);
+    expect(serialized).toEqual({
+      code: 'cc-by-sa-4.0',
+      name: 'CC BY-SA 4.0',
+      url: 'https://example.org/licenses/by-sa/4.0',
+      groups: ['cc', 'cc4'],
+    });
+  });
+
+  it('does not fail if the object misses the required keys', () => {
+    const serialized = serialize({});
+    expect(serialized).toEqual({
+      code: undefined,
+      name: undefined,
+      url: undefined,
+      groups: undefined,
+    });
+  });
+});

--- a/services/util/serializers.test.js
+++ b/services/util/serializers.test.js
@@ -1,15 +1,14 @@
 const serializers = require('./serializers');
+const licenseFactory = require('../../__helpers__/licenseFactory');
 
 describe('license()', () => {
   const { license: serialize } = serializers;
-  const license = {
+  const license = licenseFactory({
     id: 'cc-by-sa-4.0',
     name: 'CC BY-SA 4.0',
     groups: ['cc', 'cc4'],
-    compatibility: [],
-    regexp: /ab+c/,
     url: 'https://example.org/licenses/by-sa/4.0',
-  };
+  });
 
   it('serializes a license object into the specified format', () => {
     const serialized = serialize(license);


### PR DESCRIPTION
This adapts the response of the `license` endpoints to return more information (specified in [this ticket](https://ora.pm/project/59434/kanban/task/732295)):

```javascript
{
  code: "cc-by-sa-3.0-ported",
  name: "CC BY-SA 3.0",
  url: "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
  groups: ["cc", "cc3", "ported"]
}
```