### PR TITLE
[#9] Implement endpoint for modified attributions

### DIFF
--- a/__helpers__/attributionFactory.js
+++ b/__helpers__/attributionFactory.js
@@ -1,0 +1,30 @@
+const licenseFactory = require('./licenseFactory');
+const { Attribution } = require('../models/attribution');
+
+function attributionFactory({
+  fileInfo = {
+    rawUrl: 'https://commons.wikimedia.org/wiki/File:Eisklettern_kl_engstligenfall.jpg',
+    title: 'File:Eisklettern kl engstligenfall.jpg',
+    artistHtml:
+      '<a href="//commons.wikimedia.org/w/index.php?title=User:Bernhard&amp;action=edit&amp;redlink=1" class="new" title="User:Bernhard (page does not exist)">Bernhard</a>',
+    attributionHtml: null,
+  },
+  typeOfUse = 'online',
+  languageCode = 'de',
+  license = licenseFactory({}),
+  modification = null,
+  modificationAuthor = null,
+  isEdited = false,
+}) {
+  return new Attribution({
+    fileInfo,
+    typeOfUse,
+    languageCode,
+    license,
+    modification,
+    modificationAuthor,
+    isEdited,
+  });
+}
+
+module.exports = attributionFactory;

--- a/models/attribution.test.js
+++ b/models/attribution.test.js
@@ -1,31 +1,22 @@
 const { Attribution } = require('./attribution');
-const License = require('./license');
+const licenseFactory = require('../__helpers__/licenseFactory');
 
 describe('attribution', () => {
-  const exampleCC4License = new License({
-    id: 'cc-by-sa-4.0',
+  const exampleCC4License = licenseFactory({
     name: 'CC BY-SA 4.0',
     groups: ['cc', 'cc4'],
-    compatibility: [],
-    regexp: /^(Bild-)?CC-BY-SA(-|\/)4.0(([^-]+.+|-migrated)*)?$/i,
     url: 'https://creativecommons.org/licenses/by-sa/4.0/legalcode',
   });
 
-  const exampleCC2License = new License({
-    id: 'cc-by-sa-2.5',
+  const exampleCC2License = licenseFactory({
     name: 'CC BY-SA 2.5',
     groups: ['cc', 'cc2.5', 'ccby'],
-    compatibility: [],
-    regexp: /^CC-BY-2.5-\w+$/i,
     url: 'https://creativecommons.org/licenses/by-sa/2.5/legalcode',
   });
 
-  const examplePublicDomainLicense = new License({
-    id: 'PD-1923',
+  const examplePublicDomainLicense = licenseFactory({
     name: 'Public Domain',
     groups: ['pd'],
-    compatibility: ['cc-by-4.0', 'cc-by-sa-4.0'],
-    regexp: /PD-1923/,
     url: 'https://commons.wikimedia.org/wiki/Template:PD-1923',
   });
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -141,7 +141,7 @@ paths:
             $ref: '#/definitions/AttributionShowResponse'
       security:
         - default: []
-      summary: Generate attribution for a modifile work
+      summary: Generate attribution for a modified work
       tags:
         - attribution
   '/attribution/{languageCode}/{file}/{typeOfUse}/unmodified':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -87,6 +87,63 @@ info:
   title: attribution-generator-api
   version: 0.1.0
 paths:
+  '/attribution/{languageCode}/{file}/{typeOfUse}/modified/{modification}/{modificationAuthor}/{licenseId}':
+    get:
+      description: Generate attribution hints for the given file if that file was modified.
+      operationId: attribution.show
+      parameters:
+        - in: path
+          name: languageCode
+          required: true
+          type: string
+        - in: path
+          name: file
+          required: true
+          type: string
+        - in: path
+          name: typeOfUse
+          required: true
+          type: string
+        - in: path
+          name: modification
+          required: true
+          type: string
+        - in: path
+          name: modificationAuthor
+          required: true
+          type: string
+        - in: path
+          name: licenseId
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        '400':
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/BadRequestErrorResponse'
+        '422':
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/UnprocessableEntityErrorResponse'
+        '500':
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+        '503':
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/ServiceUnavailableErrorResponse'
+        default:
+          description: ''
+          schema:
+            $ref: '#/definitions/AttributionShowResponse'
+      security:
+        - default: []
+      summary: Generate attribution for a modifile work
+      tags:
+        - attribution
   '/attribution/{languageCode}/{file}/{typeOfUse}/unmodified':
     get:
       description: Generate attribution hints for the given file.

--- a/routes/__snapshots__/attribution.test.js.snap
+++ b/routes/__snapshots__/attribution.test.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`attribution routes GET /attribution/... (modified) returns 500 for any generic error 1`] = `
+Object {
+  "error": "Internal Server Error",
+  "message": "An internal server error occurred",
+  "statusCode": 500,
+}
+`;
+
+exports[`attribution routes GET /attribution/... (modified) returns an error when the requested a license we do not know 1`] = `
+Object {
+  "error": "Not Found",
+  "message": "license-not-found",
+  "statusCode": 404,
+}
+`;
+
+exports[`attribution routes GET /attribution/... (modified) returns an error when the requested a typeOfUse we do not know 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": "Invalid request params input",
+  "statusCode": 400,
+}
+`;
+
+exports[`attribution routes GET /attribution/... (modified) returns attribution information for the given file 1`] = `
+Object {
+  "attributionHtml": "Photograph by <a href=\\"https://commons.wikimedia.org/wiki/User:Rama\\">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr, <a href=\\"https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg\\">Apple_Lisa2-IMG_1517</a>, cropped by the great modificator, <a href=\\"https://creativecommons.org/licenses/by-sa/2.5/legalcode\\" rel=\\"license\\">CC BY-SA 2.5</a>",
+  "attributionPlain": "Photograph by Rama, Wikimedia Commons, Cc-by-sa-2.0-fr (https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg), „Apple_Lisa2-IMG_1517“, cropped by the great modificator, https://creativecommons.org/licenses/by-sa/2.5/legalcode",
+  "licenseId": "cc-by-sa-2.5",
+  "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.5/legalcode",
+}
+`;
+
 exports[`attribution routes GET /attribution/... (unmodified) returns 500 for any generic error 1`] = `
 Object {
   "error": "Internal Server Error",

--- a/routes/attribution.integration.test.js
+++ b/routes/attribution.integration.test.js
@@ -79,4 +79,80 @@ describe('attribution routes', () => {
       });
     });
   });
+
+  describe('GET /attribution/... (modified)', () => {
+    const defaults = {
+      languageCode: 'en',
+      file: 'File:Foobar.jpg',
+      typeOfUse: 'online',
+      modification: 'cropped',
+      creator: 'the great modificator',
+      licenseId: 'cc-zero',
+    };
+
+    const attribution = {
+      licenseId: 'cc-zero',
+      licenseUrl: 'https://creativecommons.org/publicdomain/zero/1.0/legalcode',
+      attributionHtml:
+        '<a href="https://commons.wikimedia.org/wiki/User:Kaldari">Kaldari</a>, <a href="https://upload.wikimedia.org/wikipedia/commons/3/3a/Foobar.jpg">Foobar</a>, cropped by the great modificator, <a href="https://creativecommons.org/publicdomain/zero/1.0/legalcode" rel="license">CC0 1.0</a>',
+      attributionPlain:
+        'Kaldari (https://upload.wikimedia.org/wikipedia/commons/3/3a/Foobar.jpg), „Foobar“, cropped by the great modificator, https://creativecommons.org/publicdomain/zero/1.0/legalcode',
+    };
+
+    function options(overrides = {}) {
+      const params = { ...defaults, ...overrides };
+      const url = `/attribution/${params.languageCode}/${params.file}/${
+        params.typeOfUse
+      }/modified/${params.modification}/${params.creator}/${params.licenseId}`;
+      return { url, method: 'GET' };
+    }
+
+    async function subject(overrides) {
+      return context.inject(options(overrides));
+    }
+
+    it('returns the attribution', async () => {
+      const response = await subject({});
+
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchObject(attribution);
+    });
+
+    it('returns a proper error for unknown typeOfUse', async () => {
+      const response = await subject({ typeOfUse: 'does-not-exist' });
+
+      expect(response.status).toBe(400);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchObject({
+        error: 'Bad Request',
+        message: 'Invalid request params input',
+        statusCode: 400,
+      });
+    });
+
+    it('returns a proper error for weird file urls', async () => {
+      const response = await subject({ file: 'does-not-exist' });
+
+      expect(response.status).toBe(422);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchObject({
+        error: 'Unprocessable Entity',
+        message: 'invalid-url',
+        statusCode: 422,
+      });
+    });
+
+    it('returns a proper error for an unknown licenseId', async () => {
+      const response = await subject({ licenseId: 'does-not-exist' });
+
+      expect(response.status).toBe(404);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchObject({
+        error: 'Not Found',
+        message: 'license-not-found',
+        statusCode: 404,
+      });
+    });
+  });
 });

--- a/routes/attribution.js
+++ b/routes/attribution.js
@@ -89,7 +89,7 @@ routes.push({
   ),
   method: 'GET',
   options: {
-    description: 'Generate attribution for a modifile work',
+    description: 'Generate attribution for a modified work',
     notes: 'Generate attribution hints for the given file if that file was modified.',
     validate: {
       params: {

--- a/routes/attribution.js
+++ b/routes/attribution.js
@@ -1,4 +1,5 @@
 const Joi = require('joi');
+const assert = require('assert');
 
 const { knownLanguages, knownTypesOfUse, Attribution } = require('../models/attribution');
 const errors = require('../services/util/errors');
@@ -21,6 +22,8 @@ const attributionSchema = Joi.object()
 
 function handleError(h, { message }) {
   switch (message) {
+    case errors.licenseNotFound:
+      return h.error(message, { statusCode: 404 });
     case errors.invalidUrl:
     case errors.validationError:
       return h.error(message, { statusCode: 422 });
@@ -72,6 +75,76 @@ routes.push({
         languageCode,
         typeOfUse,
         fileInfo,
+      });
+      return h.response({
+        licenseId: license.id,
+        licenseUrl: license.url,
+        attributionHtml: attribution.html(),
+        attributionPlain: attribution.plainText(),
+      });
+    } catch (error) {
+      return handleError(h, error);
+    }
+  },
+});
+
+routes.push({
+  path: prefix(
+    '/{languageCode}/{file}/{typeOfUse}/modified/{modification}/{modificationAuthor}/{licenseId}'
+  ),
+  method: 'GET',
+  options: {
+    description: 'Generate attribution for a modifile work',
+    notes: 'Generate attribution hints for the given file if that file was modified.',
+    validate: {
+      params: {
+        languageCode: Joi.string().valid(knownLanguages),
+        file: Joi.string(),
+        typeOfUse: Joi.string().valid(knownTypesOfUse),
+        modification: Joi.string(),
+        modificationAuthor: Joi.string(),
+        licenseId: Joi.string(),
+      },
+    },
+    response: {
+      schema: attributionSchema,
+      status: {
+        400: definitions.errors['400'],
+        422: definitions.errors['422'],
+        500: definitions.errors['500'],
+        503: definitions.errors['503'],
+      },
+    },
+    plugins: {
+      'hapi-swaggered': {
+        operationId: 'attribution.show',
+        security: [{ default: [] }],
+      },
+    },
+  },
+  handler: async (request, h) => {
+    const { fileData, licenseStore } = request.server.app.services;
+    const {
+      languageCode,
+      file,
+      typeOfUse,
+      modification,
+      modificationAuthor,
+      licenseId,
+    } = request.params;
+    try {
+      const fileInfo = await fileData.getFileData(file);
+      const license = licenseStore.getLicenseById(licenseId);
+      assert.ok(license, errors.licenseNotFound);
+
+      const attribution = new Attribution({
+        isEdited: true,
+        license,
+        languageCode,
+        typeOfUse,
+        fileInfo,
+        modification,
+        modificationAuthor,
       });
       return h.response({
         licenseId: license.id,

--- a/routes/attribution.test.js
+++ b/routes/attribution.test.js
@@ -179,8 +179,8 @@ describe('attribution routes', () => {
     it('returns an error when the requested a typeOfUse we do not know', async () => {
       const response = await subject({ typeOfUse: 'for the lulz' });
 
-      expect(services.fileData.getFileData).not.toHaveBeenCalledWith;
-      expect(services.licenseStore.getLicenseById).not.toHaveBeenCalledWith;
+      expect(services.fileData.getFileData).not.toHaveBeenCalledWith();
+      expect(services.licenseStore.getLicenseById).not.toHaveBeenCalledWith();
       expect(response.status).toBe(400);
       expect(response.type).toBe('application/json');
       expect(response.payload).toMatchSnapshot();

--- a/routes/attribution.test.js
+++ b/routes/attribution.test.js
@@ -1,5 +1,5 @@
 const setup = require('./__helpers__/setup');
-const License = require('../models/license');
+const licenseFactory = require('../__helpers__/licenseFactory');
 
 describe('attribution routes', () => {
   const services = {
@@ -15,12 +15,10 @@ describe('attribution routes', () => {
     attributionHtml:
       'Photograph by <a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr',
   };
-  const license = new License({
+  const license = licenseFactory({
     id: 'cc-by-sa-2.5',
     name: 'CC BY-SA 2.5',
     groups: ['cc', 'cc2.5', 'ccby'],
-    compatibility: [],
-    regexp: /^CC-BY-2.5-\w+$/i,
     url: 'https://creativecommons.org/licenses/by-sa/2.5/legalcode',
   });
 

--- a/routes/attribution.test.js
+++ b/routes/attribution.test.js
@@ -5,6 +5,7 @@ describe('attribution routes', () => {
   const services = {
     fileData: { getFileData: jest.fn() },
     licenses: { getLicense: jest.fn() },
+    licenseStore: { getLicenseById: jest.fn() },
   };
   const fileInfoMock = {
     title: 'File:Apple_Lisa2-IMG_1517.jpg',
@@ -96,6 +97,91 @@ describe('attribution routes', () => {
       expect(services.fileData.getFileData).toHaveBeenCalledWith(file);
       expect(services.licenses.getLicense).toHaveBeenCalledWith(fileInfoMock);
       expect(response.status).toBe(422);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
+  });
+
+  describe('GET /attribution/... (modified)', () => {
+    const file = 'File:Foobar.jpg';
+    const languageCode = 'en';
+    const typeOfUse = 'online';
+    const modification = 'cropped';
+    const modificationAuthor = 'the great modificator';
+    const licenseId = 'cc-by-sa-2.5';
+
+    const defaults = {
+      languageCode,
+      file,
+      typeOfUse,
+      modification,
+      modificationAuthor,
+      licenseId,
+    };
+
+    function options(overrides = {}) {
+      const params = { ...defaults, ...overrides };
+      const url = `/attribution/${params.languageCode}/${params.file}/${
+        params.typeOfUse
+      }/modified/${params.modification}/${params.modificationAuthor}/${params.licenseId}`;
+      return { method: 'GET', url };
+    }
+
+    async function subject(overrides = {}) {
+      return context.inject(options(overrides));
+    }
+
+    beforeEach(() => {
+      services.fileData.getFileData.mockResolvedValue(fileInfoMock);
+      services.licenseStore.getLicenseById.mockImplementation(() => license);
+    });
+
+    afterEach(() => {
+      services.fileData.getFileData.mockReset();
+      services.licenseStore.getLicenseById.mockReset();
+    });
+
+    it('returns attribution information for the given file', async () => {
+      const response = await subject();
+
+      expect(services.fileData.getFileData).toHaveBeenCalledWith(file);
+      expect(services.licenseStore.getLicenseById).toHaveBeenCalledWith(licenseId);
+
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
+
+    it('returns 500 for any generic error', async () => {
+      services.fileData.getFileData.mockImplementation(() => {
+        throw new Error('some error');
+      });
+      const response = await subject();
+
+      expect(services.fileData.getFileData).toHaveBeenCalledWith(file);
+      expect(services.licenseStore.getLicenseById).not.toHaveBeenCalledWith();
+      expect(response.status).toBe(500);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
+
+    it('returns an error when the requested a license we do not know', async () => {
+      services.licenseStore.getLicenseById.mockImplementation(() => undefined);
+      const response = await subject();
+
+      expect(services.fileData.getFileData).toHaveBeenCalledWith(file);
+      expect(services.licenseStore.getLicenseById).toHaveBeenCalledWith(licenseId);
+      expect(response.status).toBe(404);
+      expect(response.type).toBe('application/json');
+      expect(response.payload).toMatchSnapshot();
+    });
+
+    it('returns an error when the requested a typeOfUse we do not know', async () => {
+      const response = await subject({ typeOfUse: 'for the lulz' });
+
+      expect(services.fileData.getFileData).not.toHaveBeenCalledWith;
+      expect(services.licenseStore.getLicenseById).not.toHaveBeenCalledWith;
+      expect(response.status).toBe(400);
       expect(response.type).toBe('application/json');
       expect(response.payload).toMatchSnapshot();
     });

--- a/services/util/errors.js
+++ b/services/util/errors.js
@@ -3,4 +3,5 @@ module.exports = {
   apiUnavailabe: 'api-unavailable',
   emptyResponse: 'empty-response',
   validationError: 'validation-error',
+  licenseNotFound: 'license-not-found',
 };

--- a/services/util/serializers.js
+++ b/services/util/serializers.js
@@ -3,4 +3,17 @@ function license(licenseObject) {
   return { code, name, url, groups };
 }
 
-module.exports = { license };
+function attribution(attributionObject) {
+  const { id: licenseId, url: licenseUrl } = attributionObject.license || {};
+  return {
+    licenseId,
+    licenseUrl,
+    attributionHtml: attributionObject.html ? attributionObject.html() : undefined,
+    attributionPlain: attributionObject.plainText ? attributionObject.plainText() : undefined,
+  };
+}
+
+module.exports = {
+  license,
+  attribution,
+};

--- a/services/util/serializers.test.js
+++ b/services/util/serializers.test.js
@@ -1,5 +1,6 @@
 const serializers = require('./serializers');
 const licenseFactory = require('../../__helpers__/licenseFactory');
+const attributionFactory = require('../../__helpers__/attributionFactory');
 
 describe('license()', () => {
   const { license: serialize } = serializers;
@@ -11,8 +12,7 @@ describe('license()', () => {
   });
 
   it('serializes a license object into the specified format', () => {
-    const serialized = serialize(license);
-    expect(serialized).toEqual({
+    expect(serialize(license)).toEqual({
       code: 'cc-by-sa-4.0',
       name: 'CC BY-SA 4.0',
       url: 'https://example.org/licenses/by-sa/4.0',
@@ -21,12 +21,47 @@ describe('license()', () => {
   });
 
   it('does not fail if the object misses the required keys', () => {
-    const serialized = serialize({});
-    expect(serialized).toEqual({
+    expect(serialize({})).toEqual({
       code: undefined,
       name: undefined,
       url: undefined,
       groups: undefined,
+    });
+  });
+});
+
+describe('attribution()', () => {
+  const { attribution: serialize } = serializers;
+  const license = licenseFactory({
+    id: 'licenseId',
+    name: 'licenseName',
+    groups: [],
+    url: 'licenseUrl',
+  });
+  const attribution = attributionFactory({
+    license,
+    fileInfo: {
+      rawUrl: 'file_url',
+      title: 'file_title',
+      artistHtml: 'artist',
+    },
+  });
+
+  it('serializes a attribution object into the specified format', () => {
+    expect(serialize(attribution)).toEqual({
+      licenseId: 'licenseId',
+      licenseUrl: 'licenseUrl',
+      attributionHtml: 'artist, <a href="file_url">file_title</a>, <a href="licenseUrl" rel="license">licenseName</a>',
+      attributionPlain: 'artist (file_url), „file_title“, licenseUrl',
+    });
+  });
+
+  it('does not fail if the object misses the required keys', () => {
+    expect(serialize({})).toEqual({
+      licenseId: undefined,
+      licenseUrl: undefined,
+      attributionHtml: undefined,
+      attributionPlain: undefined,
     });
   });
 });

--- a/services/util/serializers.test.js
+++ b/services/util/serializers.test.js
@@ -51,7 +51,8 @@ describe('attribution()', () => {
     expect(serialize(attribution)).toEqual({
       licenseId: 'licenseId',
       licenseUrl: 'licenseUrl',
-      attributionHtml: 'artist, <a href="file_url">file_title</a>, <a href="licenseUrl" rel="license">licenseName</a>',
+      attributionHtml:
+        'artist, <a href="file_url">file_title</a>, <a href="licenseUrl" rel="license">licenseName</a>',
       attributionPlain: 'artist (file_url), „file_title“, licenseUrl',
     });
   });


### PR DESCRIPTION
Implements the endpoint that receives `/attribution/:language_code/:identifier/:type_of_use/modified/:modification/:creator/:license_id` and returns the suggested attribution for this file. Specified in [this ticket](https://ora.pm/project/59434/kanban/task/689960).

The endpoint creates an Attribution object and returns json of the form:

```json
{
    "license_code": "`the license id given in the request`",
    "license_url": "`the license url of the given license`",
    "attribution_plain": "`attribution.plainText()`",
    "attribution_html": "`attribution.html()`",
}
```