### PR TITLE
[#20] Make sure /fileinfo and /files/ handles all URLs specified in the PDF

### DIFF
--- a/__helpers__/attributionFactory.js
+++ b/__helpers__/attributionFactory.js
@@ -5,6 +5,7 @@ function attributionFactory({
   fileInfo = {
     rawUrl: 'https://commons.wikimedia.org/wiki/File:Eisklettern_kl_engstligenfall.jpg',
     title: 'File:Eisklettern kl engstligenfall.jpg',
+    normalizedTitle: 'File:Eisklettern kl engstligenfall.jpg',
     artistHtml:
       '<a href="//commons.wikimedia.org/w/index.php?title=User:Bernhard&amp;action=edit&amp;redlink=1" class="new" title="User:Bernhard (page does not exist)">Bernhard</a>',
     attributionHtml: null,

--- a/models/attribution.js
+++ b/models/attribution.js
@@ -29,7 +29,7 @@ function validateParams({
   isEdited,
 }) {
   assert(isStringPresent(fileInfo.rawUrl), errors.validationError);
-  assert(isStringPresent(fileInfo.title), errors.validationError);
+  assert(isStringPresent(fileInfo.normalizedTitle), errors.validationError);
   assert(knownTypesOfUse.includes(typeOfUse), errors.validationError);
   assert(knownLanguages.includes(languageCode), errors.validationError);
   assert([true, false].includes(isEdited), errors.validationError);
@@ -210,7 +210,12 @@ function getAttributionAsTextWithLinks(self) {
 class Attribution {
   constructor(params) {
     validateParams(params);
-    const { title: fileTitle, rawUrl: fileUrl, artistHtml, attributionHtml } = params.fileInfo;
+    const {
+      normalizedTitle: fileTitle,
+      rawUrl: fileUrl,
+      artistHtml,
+      attributionHtml,
+    } = params.fileInfo;
 
     Object.assign(this, {
       ...params,

--- a/models/attribution.test.js
+++ b/models/attribution.test.js
@@ -24,6 +24,7 @@ describe('attribution', () => {
     fileInfo: {
       rawUrl: 'https://commons.wikimedia.org/wiki/File:Eisklettern_kl_engstligenfall.jpg',
       title: 'File:Eisklettern kl engstligenfall.jpg',
+      normalizedTitle: 'File:Eisklettern kl engstligenfall.jpg',
       artistHtml:
         '<a href="//commons.wikimedia.org/w/index.php?title=User:Bernhard&amp;action=edit&amp;redlink=1" class="new" title="User:Bernhard (page does not exist)">Bernhard</a>',
       attributionHtml: null,
@@ -46,11 +47,13 @@ describe('attribution', () => {
 
   describe('validations', () => {
     it('asserts valid fileInfo.rawUrl', () => {
-      expect(() => newAttribution({ fileInfo: { rawUrl: 123, title: 'title' } })).toThrow();
+      expect(() =>
+        newAttribution({ fileInfo: { rawUrl: 123, normalizedTtle: 'title' } })
+      ).toThrow();
     });
 
     it('asserts valid fileInfo.title', () => {
-      expect(() => newAttribution({ fileInfo: { rawUrl: 'url', title: '' } })).toThrow();
+      expect(() => newAttribution({ fileInfo: { rawUrl: 'url', normalizedTitle: '' } })).toThrow();
     });
 
     it('asserts valid typeOfUse', () => {
@@ -164,7 +167,7 @@ describe('attribution', () => {
     const subject = newAttribution({
       fileInfo: {
         rawUrl: 'https://commons.wikimedia.org/wiki/File:Eisklettern_kl_engstligenfall.jpg',
-        title: 'File:Eisklettern kl engstligenfall.jpg',
+        normalizedTitle: 'File:Eisklettern kl engstligenfall.jpg',
         artistHtml: 'artistHtml',
         attributionHtml:
           '<a href="https://en.wikipedia.org/wiki/User:Rhorn" class="extiw" title="en:User:Rhorn">Rhorn</a> at the <a href="https://en.wikipedia.org/wiki/" class="extiw" title="w:">English language Wikipedia</a>',
@@ -188,7 +191,7 @@ describe('attribution', () => {
     const subject = newAttribution({
       fileInfo: {
         rawUrl: 'https://commons.wikimedia.org/wiki/File:Eisklettern_kl_engstligenfall.jpg',
-        title: 'File:Eisklettern kl engstligenfall.jpg',
+        normalizedTitle: 'File:Eisklettern kl engstligenfall.jpg',
       },
     });
 

--- a/routes/__snapshots__/attribution.test.js.snap
+++ b/routes/__snapshots__/attribution.test.js.snap
@@ -26,8 +26,8 @@ Object {
 
 exports[`attribution routes GET /attribution/... (modified) returns attribution information for the given file 1`] = `
 Object {
-  "attributionHtml": "Photograph by <a href=\\"https://commons.wikimedia.org/wiki/User:Rama\\">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr, <a href=\\"https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg\\">Apple_Lisa2-IMG_1517</a>, cropped by the great modificator, <a href=\\"https://creativecommons.org/licenses/by-sa/2.5/legalcode\\" rel=\\"license\\">CC BY-SA 2.5</a>",
-  "attributionPlain": "Photograph by Rama, Wikimedia Commons, Cc-by-sa-2.0-fr (https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg), „Apple_Lisa2-IMG_1517“, cropped by the great modificator, https://creativecommons.org/licenses/by-sa/2.5/legalcode",
+  "attributionHtml": "Photograph by <a href=\\"https://commons.wikimedia.org/wiki/User:Rama\\">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr, <a href=\\"https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg\\">Apple Lisa2-IMG 1517</a>, cropped by the great modificator, <a href=\\"https://creativecommons.org/licenses/by-sa/2.5/legalcode\\" rel=\\"license\\">CC BY-SA 2.5</a>",
+  "attributionPlain": "Photograph by Rama, Wikimedia Commons, Cc-by-sa-2.0-fr (https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg), „Apple Lisa2-IMG 1517“, cropped by the great modificator, https://creativecommons.org/licenses/by-sa/2.5/legalcode",
   "licenseId": "cc-by-sa-2.5",
   "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.5/legalcode",
 }
@@ -51,8 +51,8 @@ Object {
 
 exports[`attribution routes GET /attribution/... (unmodified) returns attribution information for the given file 1`] = `
 Object {
-  "attributionHtml": "Photograph by <a href=\\"https://commons.wikimedia.org/wiki/User:Rama\\">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr, <a href=\\"https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg\\">Apple_Lisa2-IMG_1517</a>, <a href=\\"https://creativecommons.org/licenses/by-sa/2.5/legalcode\\" rel=\\"license\\">CC BY-SA 2.5</a>",
-  "attributionPlain": "Photograph by Rama, Wikimedia Commons, Cc-by-sa-2.0-fr (https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg), „Apple_Lisa2-IMG_1517“, https://creativecommons.org/licenses/by-sa/2.5/legalcode",
+  "attributionHtml": "Photograph by <a href=\\"https://commons.wikimedia.org/wiki/User:Rama\\">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr, <a href=\\"https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg\\">Apple Lisa2-IMG 1517</a>, <a href=\\"https://creativecommons.org/licenses/by-sa/2.5/legalcode\\" rel=\\"license\\">CC BY-SA 2.5</a>",
+  "attributionPlain": "Photograph by Rama, Wikimedia Commons, Cc-by-sa-2.0-fr (https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg), „Apple Lisa2-IMG 1517“, https://creativecommons.org/licenses/by-sa/2.5/legalcode",
   "licenseId": "cc-by-sa-2.5",
   "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.5/legalcode",
 }

--- a/routes/attribution.test.js
+++ b/routes/attribution.test.js
@@ -9,6 +9,7 @@ describe('attribution routes', () => {
   };
   const fileInfoMock = {
     title: 'File:Apple_Lisa2-IMG_1517.jpg',
+    normalizedTitle: 'File:Apple Lisa2-IMG 1517.jpg',
     rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg',
     wikiUrl: 'https://commons.wikimedia.org/',
     artistHtml:

--- a/services/__fixtures__/expectedFiles.js
+++ b/services/__fixtures__/expectedFiles.js
@@ -1,0 +1,383 @@
+module.exports = [
+  {
+    title: 'Datei:Luftkurort Königsberg.jpg',
+    descriptionUrl: 'https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg',
+    fileSize: 181752,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg',
+    thumbnail: {
+      height: 194,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Baumeister-Königsberg.JPG',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG',
+    fileSize: 357387,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG',
+    thumbnail: {
+      height: 400,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Commons-logo.svg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Commons-logo.svg',
+    fileSize: 932,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg',
+    thumbnail: {
+      height: 403,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:DEU Königsberg COA.svg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg',
+    fileSize: 38875,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg',
+    thumbnail: {
+      height: 346,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Germany adm location map.svg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg',
+    fileSize: 657974,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg',
+    thumbnail: {
+      height: 356,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Karte-HSC-Ex.png',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png',
+    fileSize: 32503,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png',
+    thumbnail: {
+      height: 254,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Konigsberg Altstadt-1.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg',
+    fileSize: 78351,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg',
+    thumbnail: {
+      height: 231,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Konigsberg Altstadt-2.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg',
+    fileSize: 60336,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg',
+    thumbnail: {
+      height: 231,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Altershausen.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg',
+    fileSize: 4931020,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Bühl.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg',
+    fileSize: 4667382,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Dörflis.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg',
+    fileSize: 4670674,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg',
+    thumbnail: {
+      height: 400,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Hellingen.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg',
+    fileSize: 3904181,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg',
+    thumbnail: {
+      height: 400,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Hofstetten.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg',
+    fileSize: 4420981,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Junkersdorf.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg',
+    fileSize: 3364682,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Kottenbrunn.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg',
+    fileSize: 5019771,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Köslau.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg',
+    fileSize: 4789750,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Römershofen.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg',
+    fileSize: 3634911,
+    rawUrl:
+      'https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg Unfinden.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg',
+    fileSize: 4262148,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg',
+    thumbnail: {
+      height: 400,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Königsberg in Bayern in HAS.svg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg',
+    fileSize: 371710,
+    rawUrl:
+      'https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg',
+    thumbnail: {
+      height: 307,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Luftbild-koenigsberg-bayern.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg',
+    fileSize: 661989,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Marienkirche-waechterturm-koenigsberg.jpg',
+    descriptionUrl:
+      'https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg',
+    fileSize: 1107053,
+    rawUrl:
+      'https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg',
+    thumbnail: {
+      height: 400,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Marienstrasse.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg',
+    fileSize: 174739,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg',
+    thumbnail: {
+      height: 265,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Marktbrunnen-koenigsberg.jpg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg',
+    fileSize: 185583,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg',
+    thumbnail: {
+      height: 280,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Reddot.svg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Reddot.svg',
+    fileSize: 430,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg',
+    thumbnail: {
+      height: 300,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Regiomontanus-Koenigsberg.JPG',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG',
+    fileSize: 660842,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Roland-Koenigsberg.JPG',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG',
+    fileSize: 284295,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG',
+    thumbnail: {
+      height: 400,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Seckendorff-Tafel.JPG',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG',
+    fileSize: 603140,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG',
+    thumbnail: {
+      height: 200,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG',
+    descriptionUrl:
+      'https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG',
+    fileSize: 9568514,
+    rawUrl:
+      'https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG',
+    thumbnail: {
+      height: 450,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Wappen Landkreis Haßberge.svg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg',
+    fileSize: 95383,
+    rawUrl:
+      'https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg',
+    thumbnail: {
+      height: 329,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Westansicht-schlossberg-koenigsberg.jpg',
+    descriptionUrl:
+      'https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg',
+    fileSize: 230508,
+    rawUrl:
+      'https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg',
+    thumbnail: {
+      height: 225,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg',
+      width: 300,
+    },
+  },
+  {
+    title: 'Datei:Wikisource-logo.svg',
+    descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg',
+    fileSize: 16160,
+    rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg',
+    thumbnail: {
+      height: 315,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png',
+      width: 300,
+    },
+  },
+];

--- a/services/__fixtures__/imageInfoWithoutNormalization.js
+++ b/services/__fixtures__/imageInfoWithoutNormalization.js
@@ -1,0 +1,115 @@
+module.exports = {
+  pages: {
+    '-1': {
+      ns: 6,
+      title: 'File:Apple Lisa2-IMG 1517.jpg',
+      missing: '',
+      known: '',
+      imagerepository: 'shared',
+      imageinfo: [
+        {
+          thumburl:
+            'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Apple_Lisa2-IMG_1517.jpg/300px-Apple_Lisa2-IMG_1517.jpg',
+          thumbwidth: 300,
+          thumbheight: 300,
+          url: 'https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg',
+          descriptionurl: 'https://commons.wikimedia.org/wiki/File:Apple_Lisa2-IMG_1517.jpg',
+          descriptionshorturl: 'https://commons.wikimedia.org/w/index.php?curid=17540984',
+          extmetadata: {
+            DateTime: {
+              value: '2011-12-01 14:17:15',
+              source: 'mediawiki-metadata',
+              hidden: '',
+            },
+            ObjectName: {
+              value: 'Apple Lisa2-IMG 1517',
+              source: 'mediawiki-metadata',
+              hidden: '',
+            },
+            CommonsMetadataExtension: {
+              value: 1.2,
+              source: 'extension',
+              hidden: '',
+            },
+            Categories: {
+              value:
+                'All media supported by Wikimedia CH|Apple Lisa|CeCILL|Musée Bolo|Self-published work|Supported by Wikimedia CH',
+              source: 'commons-categories',
+              hidden: '',
+            },
+            Assessments: {
+              value: '',
+              source: 'commons-categories',
+              hidden: '',
+            },
+            ImageDescription: {
+              value:
+                'The making of this document was supported by <b><a href="https://meta.wikimedia.org/wiki/Wikimedia_CH" class="extiw" title="m:Wikimedia CH">Wikimedia CH</a></b>. <b><small>(<a rel="nofollow" class="external text" href="https://www.wikimedia.ch/">Submit your project!</a>)</small></b><br>\nFor all the files concerned, please see the category <a href="//commons.wikimedia.org/wiki/Category:Supported_by_Wikimedia_CH" title="Category:Supported by Wikimedia CH">Supported by Wikimedia CH</a>.',
+              source: 'commons-desc-page',
+            },
+            DateTimeOriginal: {
+              value: '',
+              source: 'commons-desc-page',
+            },
+            Credit: {
+              value: '<span class="int-own-work" lang="en">Own work</span>',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            Artist: {
+              value:
+                '<a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a> &amp; Musée Bolo',
+              source: 'commons-desc-page',
+            },
+            Permission: {
+              value: '<i>You may select the license of your choice.</i>',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            LicenseShortName: {
+              value: 'CC BY-SA 2.0 fr',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            UsageTerms: {
+              value: 'Creative Commons Attribution-Share Alike 2.0 fr',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            AttributionRequired: {
+              value: 'true',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            Attribution: {
+              value:
+                'Photograph by <a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            LicenseUrl: {
+              value: 'https://creativecommons.org/licenses/by-sa/2.0/fr/deed.en',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            Copyrighted: {
+              value: 'True',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            Restrictions: {
+              value: '',
+              source: 'commons-desc-page',
+              hidden: '',
+            },
+            License: {
+              value: 'cc-by-sa-2.0-fr',
+              source: 'commons-templates',
+              hidden: '',
+            },
+          },
+        },
+      ],
+    },
+  },
+};

--- a/services/fileData.integration.test.js
+++ b/services/fileData.integration.test.js
@@ -57,6 +57,7 @@ describe('FileData', () => {
         // parameters other than title are ignored
         'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
         'https://commons.m.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
+        'http//commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
         '//commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
         'commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
 

--- a/services/fileData.integration.test.js
+++ b/services/fileData.integration.test.js
@@ -13,11 +13,13 @@ describe('FileData', () => {
     [
       {
         title: 'File:Helene_Fischer_2010.jpg',
+        normalizedTitle: 'File:Helene Fischer 2010.jpg',
         wikiUrl: 'https://commons.wikimedia.org/',
         rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
         artistHtml:
           '<a href="//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1" class="new" title="User:Fleyx24 (page does not exist)">Fleyx24</a>',
         attributionHtml: null,
+        mediaType: 'BITMAP'
       },
       [
         'File:Helene_Fischer_2010.jpg',
@@ -60,12 +62,14 @@ describe('FileData', () => {
     // the following are expected to be “normalized” to https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg
     [
       {
-        title: '1 FC Bamberg - 1 FC Nürnberg 1901.jpg',
+        title: 'File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        normalizedTitle: 'Datei:1 FC Bamberg - 1 FC Nürnberg 1901.jpg',
         wikiUrl: 'https://de.wikipedia.org/',
         rawUrl:
           'https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         artistHtml: '<p>unbekannt\n</p>',
         attributionHtml: null,
+        mediaType: 'BITMAP'
       },
       [
         'https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',

--- a/services/fileData.integration.test.js
+++ b/services/fileData.integration.test.js
@@ -1,0 +1,122 @@
+const Client = require('../services/util/client');
+const FileData = require('./fileData');
+
+describe('FileData', () => {
+  const client = new Client();
+  const fileData = new FileData({ client });
+
+  // We got a list of example url that we need to understand and match.
+  // This spec calls all these examples and expects they work against a known
+  // good state (snapshop).
+  const inputs = [
+    // the following are expected to be “normalized” to https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg
+    [
+      {
+        title: 'File:Helene_Fischer_2010.jpg',
+        wikiUrl: 'https://commons.wikimedia.org/',
+        rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
+        artistHtml:
+          '<a href="//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1" class="new" title="User:Fleyx24 (page does not exist)">Fleyx24</a>',
+        attributionHtml: null,
+      },
+      [
+        'File:Helene_Fischer_2010.jpg',
+
+        'https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+        'https://commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+        'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+        'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+
+        'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
+        'https://commons.m.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
+        'http://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
+        'commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
+
+        'https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
+        'http://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
+        'upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
+
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
+        'http://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
+        'upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
+
+        'https://commons.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
+        'https://commons.m.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
+        'http://commons.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
+        'commons.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
+
+        // parameters other than title are ignored
+        'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
+        'https://commons.m.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
+        'commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
+
+        // parameters other than title are ignored
+        'https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
+        'https://commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
+        'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
+        'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
+      ],
+    ],
+    // the following are expected to be “normalized” to https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg
+    [
+      {
+        title: '1 FC Bamberg - 1 FC Nürnberg 1901.jpg',
+        wikiUrl: 'https://de.wikipedia.org/',
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        artistHtml: '<p>unbekannt\n</p>',
+        attributionHtml: null,
+      },
+      [
+        'https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'https://de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'http://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+
+        'https://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'https://de.m.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'http://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+
+        'https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'http://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+
+        'https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'http://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+
+        'https://de.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'https://de.m.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'http://de.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        'de.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+
+        // 'parameters other than title are ignored
+        'https://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
+        'https://de.m.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
+        'http://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
+        'de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
+
+        // parameters other than title are ignored
+        'https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
+        'https://de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
+        'http://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
+        'de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
+      ],
+    ],
+  ];
+
+  inputs.forEach(normalizeExpectation => {
+    const [expectedResult, inputUrls] = normalizeExpectation;
+
+    describe(`for an input URL which normalizes to ${expectedResult.wikiUrl}`, () => {
+      inputUrls.forEach(input => {
+        it(`requesting info for ${input}`, async () => {
+          const result = await fileData.getFileData(input);
+          // console.log({ result });
+          expect(result).toEqual(expectedResult);
+        });
+      });
+    });
+  });
+});

--- a/services/fileData.integration.test.js
+++ b/services/fileData.integration.test.js
@@ -125,6 +125,43 @@ describe('FileData', () => {
         'de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
       ],
     ],
+    [
+      {
+        title: 'File:K%C3%B6nigsberg_in_Bayern',
+        normalizedTitle: 'Datei:Königsberg_in_Bayern',
+        wikiUrl: 'https://de.wikipedia.org/',
+        rawUrl: 'https://upload.wikimedia.org/wikipedia/de/f/fb/K%C3%B6nigsberg_in_Bayern.jpg',
+        artistHtml: '<p>unbekannt\n</p>',
+        attributionHtml: null,
+      },
+      [
+        'https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+        'http://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+        '//de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+        'de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+        'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+
+        // parameters other than title are ignored
+        'https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+        'http://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+        '//de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+        'de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+        'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+
+        'https://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+        'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+        '//de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+        'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+        'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+
+        // parameters other than title are ignored
+        'https://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+        'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+        '//de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+        'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+        'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+      ],
+    ],
   ];
 
   inputs.forEach(normalizeExpectation => {

--- a/services/fileData.integration.test.js
+++ b/services/fileData.integration.test.js
@@ -23,39 +23,48 @@ describe('FileData', () => {
       },
       [
         'File:Helene_Fischer_2010.jpg',
+        'Datei:Helene_Fischer_2010.jpg',
+        'Fichier:Helene_Fischer_2010.jpg',
 
         'https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
         'https://commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
         'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+        '//commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
         'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
 
         'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
         'https://commons.m.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
         'http://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
+        '//commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
         'commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
 
         'https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
         'http://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
+        '//upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
         'upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
 
         'https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
         'http://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
+        '//upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
         'upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
 
         'https://commons.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
         'https://commons.m.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
         'http://commons.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
+        '//commons.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
         'commons.wikimedia.org/wiki/Helene_Fischer#/media/File:Helene_Fischer_2010.jpg',
 
         // parameters other than title are ignored
         'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
         'https://commons.m.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
+        '//commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
         'commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
 
         // parameters other than title are ignored
         'https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
         'https://commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
         'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
+        '//commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
         'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
       ],
     ],
@@ -75,36 +84,43 @@ describe('FileData', () => {
         'https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'https://de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'http://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        '//de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 
         'https://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'https://de.m.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'http://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        '//de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 
         'https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'http://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        '//upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 
         'https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'http://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        '//upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 
         'https://de.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'https://de.m.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'http://de.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+        '//de.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'de.wikipedia.org/wiki/S%C3%BCddeutsche_Fu%C3%9Fballmeisterschaft_1901/02#/media/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 
         // 'parameters other than title are ignored
         'https://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
         'https://de.m.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
         'http://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
+        '//de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
         'de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&uselang=de',
 
         // parameters other than title are ignored
         'https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
         'https://de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
         'http://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
+        '//de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
         'de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg?foo=bar',
       ],
     ],

--- a/services/fileData.integration.test.js
+++ b/services/fileData.integration.test.js
@@ -19,7 +19,7 @@ describe('FileData', () => {
         artistHtml:
           '<a href="//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1" class="new" title="User:Fleyx24 (page does not exist)">Fleyx24</a>',
         attributionHtml: null,
-        mediaType: 'BITMAP'
+        mediaType: 'BITMAP',
       },
       [
         'File:Helene_Fischer_2010.jpg',
@@ -79,9 +79,11 @@ describe('FileData', () => {
           'https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         artistHtml: '<p>unbekannt\n</p>',
         attributionHtml: null,
-        mediaType: 'BITMAP'
+        mediaType: 'BITMAP',
       },
       [
+        'https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg',
+
         'https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'https://de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
         'http://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
@@ -126,41 +128,9 @@ describe('FileData', () => {
       ],
     ],
     [
-      {
-        title: 'File:K%C3%B6nigsberg_in_Bayern',
-        normalizedTitle: 'Datei:Königsberg_in_Bayern',
-        wikiUrl: 'https://de.wikipedia.org/',
-        rawUrl: 'https://upload.wikimedia.org/wikipedia/de/f/fb/K%C3%B6nigsberg_in_Bayern.jpg',
-        artistHtml: '<p>unbekannt\n</p>',
-        attributionHtml: null,
-      },
-      [
-        'https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
-        'http://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
-        '//de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
-        'de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
-        'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
-
-        // parameters other than title are ignored
-        'https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
-        'http://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
-        '//de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
-        'de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
-        'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
-
-        'https://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
-        'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
-        '//de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
-        'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
-        'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
-
-        // parameters other than title are ignored
-        'https://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
-        'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
-        '//de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
-        'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
-        'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
-      ],
+      // we give an article-url (not a file URL) and should give "no result" in all cases
+      {},
+      ['https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern'],
     ],
   ];
 
@@ -171,7 +141,6 @@ describe('FileData', () => {
       inputUrls.forEach(input => {
         it(`requesting info for ${input}`, async () => {
           const result = await fileData.getFileData(input);
-          // console.log({ result });
           expect(result).toEqual(expectedResult);
         });
       });

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -10,9 +10,13 @@ const defaultWikiUrl = 'https://commons.wikimedia.org/';
 function parseImageInfoResponse(response) {
   assert.ok(response.pages, errors.emptyResponse);
   const pages = Object.values(response.pages);
+  const { to: normalizedTitle } = response.normalized ? response.normalized[0] : {};
   assert.ok(pages.length === 1);
   const { imageinfo } = pages[0];
-  return imageinfo[0];
+  return {
+    normalizedTitle,
+    ...imageinfo[0],
+  };
 }
 
 function parseFileTitle(title) {
@@ -42,13 +46,18 @@ class FileData {
     const { client } = this;
     const identifier = decodeURIComponent(titleOrUrl);
     const { title, wikiUrl } = parseIdentifier(identifier);
-    const { url, extmetadata, mediatype } = await getImageInfo({ client, title, wikiUrl });
+    const { normalizedTitle, url, extmetadata, mediatype } = await getImageInfo({
+      client,
+      title,
+      wikiUrl,
+    });
     const { title: originalTitle, wikiUrl: originalWikiUrl } = parseWikiUrl(url);
     const { value: artistHtml = null } = extmetadata.Artist || {};
     const { value: attributionHtml = null } = extmetadata.Attribution || {};
 
     return {
       title: originalTitle,
+      normalizedTitle: normalizedTitle || originalTitle,
       wikiUrl: originalWikiUrl,
       rawUrl: url,
       artistHtml,

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const parseWikiUrl = require('./util/parseWikiUrl');
 const errors = require('./util/errors');
 
-const fileRegex = /^\w+:([^\/]+\.\w+)$/;
+const fileRegex = /^\w+:([^/]+\.\w+)$/;
 const defaultWikiUrl = 'https://commons.wikimedia.org/';
 
 function parseImageInfoResponse(response) {
@@ -22,7 +22,7 @@ function parseFileTitle(title) {
   const matches = title.match(fileRegex);
   return {
     title: `File:${matches[1]}`,
-    wikiUrl: defaultWikiUrl
+    wikiUrl: defaultWikiUrl,
   };
 }
 

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -12,9 +12,15 @@ function parseImageInfoResponse(response) {
   const { to: normalizedTitle } = response.normalized ? response.normalized[0] : {};
   assert.ok(pages.length === 1);
   const { imageinfo } = pages[0];
+
+  // when we gave an invalid URL (e.g. an article URL)
+  if (!imageinfo) {
+    return {};
+  }
+
   return {
     normalizedTitle,
-    ...imageinfo[0],
+    ...(imageinfo[0] || {}),
   };
 }
 
@@ -53,6 +59,12 @@ class FileData {
       title,
       wikiUrl,
     });
+
+    // when no image info could be found
+    if (!url) {
+      return {};
+    }
+
     const { title: originalTitle, wikiUrl: originalWikiUrl } = parseWikiUrl(url);
     const { value: artistHtml = null } = extmetadata.Artist || {};
     const { value: attributionHtml = null } = extmetadata.Attribution || {};

--- a/services/fileData.js
+++ b/services/fileData.js
@@ -3,8 +3,7 @@ const assert = require('assert');
 const parseWikiUrl = require('./util/parseWikiUrl');
 const errors = require('./util/errors');
 
-const urlRegex = /^(https|http)?:\/\//;
-const filePrefix = 'File:';
+const fileRegex = /^\w+:([^\/]+\.\w+)$/;
 const defaultWikiUrl = 'https://commons.wikimedia.org/';
 
 function parseImageInfoResponse(response) {
@@ -20,15 +19,18 @@ function parseImageInfoResponse(response) {
 }
 
 function parseFileTitle(title) {
-  assert.ok(title.startsWith(filePrefix), errors.invalidUrl);
-  return { title, wikiUrl: defaultWikiUrl };
+  const matches = title.match(fileRegex);
+  return {
+    title: `File:${matches[1]}`,
+    wikiUrl: defaultWikiUrl
+  };
 }
 
 function parseIdentifier(identifier) {
-  if (urlRegex.test(identifier)) {
-    return parseWikiUrl(identifier);
+  if (fileRegex.test(identifier)) {
+    return parseFileTitle(identifier);
   }
-  return parseFileTitle(identifier);
+  return parseWikiUrl(identifier);
 }
 
 async function getImageInfo({ client, title, wikiUrl }) {

--- a/services/fileData.test.js
+++ b/services/fileData.test.js
@@ -4,12 +4,14 @@ const errors = require('../services/util/errors');
 const imageInfoMock = require('./__fixtures__/imageInfo');
 const imageInfoWithoutArtistMock = require('./__fixtures__/imageInfoWithoutArtist');
 const imageInfoWithoutAttributionMock = require('./__fixtures__/imageInfoWithoutAttribution');
+const imageInfoWithoutNormalizationMock = require('./__fixtures__/imageInfoWithoutNormalization');
 
 describe('FileData', () => {
   const client = { getResultsFromApi: jest.fn() };
 
   describe('getFileData', () => {
     const title = 'File:Apple_Lisa2-IMG_1517.jpg';
+    const normalizedTitle = 'File:Apple Lisa2-IMG 1517.jpg';
     const wikiUrl = 'https://commons.wikimedia.org/';
     const artistHtml =
       '<a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a> &amp; Musée Bolo';
@@ -36,7 +38,14 @@ describe('FileData', () => {
             iiurlheight: 300,
           }
         );
-        expect(fileData).toEqual({ title, rawUrl, wikiUrl, artistHtml, attributionHtml });
+        expect(fileData).toEqual({
+          title,
+          normalizedTitle,
+          rawUrl,
+          wikiUrl,
+          artistHtml,
+          attributionHtml,
+        });
       });
 
       it('skips the artist information if not available for the file', async () => {
@@ -45,7 +54,14 @@ describe('FileData', () => {
         const service = new FileData({ client });
         const fileData = await service.getFileData(url);
 
-        expect(fileData).toEqual({ title, rawUrl, wikiUrl, artistHtml: null, attributionHtml });
+        expect(fileData).toEqual({
+          title,
+          normalizedTitle,
+          rawUrl,
+          wikiUrl,
+          artistHtml: null,
+          attributionHtml,
+        });
       });
 
       it('skips the attribution information if not available for the file', async () => {
@@ -54,7 +70,30 @@ describe('FileData', () => {
         const service = new FileData({ client });
         const fileData = await service.getFileData(url);
 
-        expect(fileData).toEqual({ title, rawUrl, wikiUrl, artistHtml, attributionHtml: null });
+        expect(fileData).toEqual({
+          title,
+          normalizedTitle,
+          rawUrl,
+          wikiUrl,
+          artistHtml,
+          attributionHtml: null,
+        });
+      });
+
+      it("returns the title if the title didn't need normalization", async () => {
+        client.getResultsFromApi.mockResolvedValueOnce(imageInfoWithoutNormalizationMock);
+
+        const service = new FileData({ client });
+        const fileData = await service.getFileData(url);
+
+        expect(fileData).toEqual({
+          title,
+          normalizedTitle: title,
+          rawUrl,
+          wikiUrl,
+          artistHtml,
+          attributionHtml,
+        });
       });
 
       it('throws an error when the imageinfo response is empty', async () => {
@@ -78,7 +117,14 @@ describe('FileData', () => {
           iilimit: 1,
           iiurlheight: 300,
         });
-        expect(fileData).toEqual({ title, rawUrl, wikiUrl, artistHtml, attributionHtml });
+        expect(fileData).toEqual({
+          title,
+          normalizedTitle,
+          rawUrl,
+          wikiUrl,
+          artistHtml,
+          attributionHtml,
+        });
       });
 
       it('throws an exception when the title has the wrong format', async () => {

--- a/services/files.integration.test.js
+++ b/services/files.integration.test.js
@@ -7,63 +7,167 @@ const Client = require('./util/client');
 describe('getPageImages()', () => {
   const client = new Client();
   const service = new Files({ client });
-  const url = 'https://de.wikipedia.org/wiki/The_Hellacopters';
+  const urls = [
+    'https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+    'http://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+    '//de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+    'de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+    'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+
+    'http://de.wikipedia.org/wiki/Königsberg_in_Bayern',
+    '//de.wikipedia.org/wiki/Königsberg_in_Bayern',
+    'de.wikipedia.org/wiki/Königsberg_in_Bayern',
+    'https://de.m.wikipedia.org/wiki/Königsberg_in_Bayern',
+
+    // parameters other than title are ignored
+    'https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+    'http://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+    '//de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+    'de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+    'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+
+    'https://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+    'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+    '//de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+    'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+    'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+
+    // parameters other than title are ignored
+    'https://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+    'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+    '//de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+    'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+    'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+  ];
   const expectedFiles = [
     {
-      title: 'Datei:Backyard babies 02.jpg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Backyard_babies_02.jpg',
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/ef/Backyard_babies_02.jpg',
-      fileSize: 112450,
+      title: 'Datei:Baumeister-Königsberg.JPG',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG',
+      fileSize: 357387,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG',
       thumbnail: {
+        height: 400,
         rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Backyard_babies_02.jpg/300px-Backyard_babies_02.jpg',
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG',
         width: 300,
-        height: 300,
       },
     },
     {
       title: 'Datei:Commons-logo.svg',
       descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Commons-logo.svg',
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg',
       fileSize: 932,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg',
       thumbnail: {
+        height: 403,
         rawUrl:
           'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png',
         width: 300,
-        height: 403,
       },
     },
     {
-      title: 'Datei:ImperialStateElectric Sonisphere2010.jpg',
-      descriptionUrl:
-        'https://commons.wikimedia.org/wiki/File:ImperialStateElectric_Sonisphere2010.jpg',
+      title: 'Datei:DEU Königsberg COA.svg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg',
+      fileSize: 38875,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg',
+      thumbnail: {
+        height: 346,
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png',
+        width: 300,
+      },
+    },
+    {
+      title: 'Datei:Germany adm location map.svg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg',
+      fileSize: 657974,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg',
+      thumbnail: {
+        height: 356,
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png',
+        width: 300,
+      },
+    },
+    {
+      title: 'Datei:Karte-HSC-Ex.png',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png',
+      fileSize: 32503,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png',
+      thumbnail: {
+        height: 254,
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png',
+        width: 300,
+      },
+    },
+    {
+      title: 'Datei:Konigsberg Altstadt-1.jpg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg',
+      fileSize: 78351,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg',
+      thumbnail: {
+        height: 231,
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg',
+        width: 300,
+      },
+    },
+    {
+      title: 'Datei:Konigsberg Altstadt-2.jpg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg',
+      fileSize: 60336,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg',
+      thumbnail: {
+        height: 231,
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg',
+        width: 300,
+      },
+    },
+    {
+      title: 'Datei:Königsberg Altershausen.jpg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg',
+      fileSize: 4931020,
       rawUrl:
-        'https://upload.wikimedia.org/wikipedia/commons/8/86/ImperialStateElectric_Sonisphere2010.jpg',
-      fileSize: 1168631,
+        'https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg',
       thumbnail: {
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/8/86/ImperialStateElectric_Sonisphere2010.jpg/300px-ImperialStateElectric_Sonisphere2010.jpg',
-        width: 300,
         height: 225,
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg',
+        width: 300,
       },
     },
     {
-      title: 'Datei:Nick royale and strings.jpg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Nick_royale_and_strings.jpg',
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/7/7b/Nick_royale_and_strings.jpg',
-      fileSize: 3068651,
+      title: 'Datei:Königsberg Bühl.jpg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg',
+      fileSize: 4667382,
+      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg',
       thumbnail: {
+        height: 225,
         rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Nick_royale_and_strings.jpg/300px-Nick_royale_and_strings.jpg',
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg',
         width: 300,
-        height: 199,
+      },
+    },
+    {
+      title: 'Datei:Königsberg Dörflis.jpg',
+      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg',
+      fileSize: 4670674,
+      rawUrl:
+        'https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg',
+      thumbnail: {
+        height: 400,
+        rawUrl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg',
+        width: 300,
       },
     },
   ];
 
-  it('returns all images with their name and url', async () => {
-    const response = await service.getPageImages(url);
-
-    expect(response).toEqual(expectedFiles);
+  urls.forEach(url => {
+    it(`when requesting files for "${url}"`, async () => {
+      const response = await service.getPageImages(url);
+      expect(response).toEqual(expectedFiles);
+    });
   });
 });

--- a/services/files.integration.test.js
+++ b/services/files.integration.test.js
@@ -1,6 +1,8 @@
 const Files = require('./files');
 const Client = require('./util/client');
 
+const expectedFiles = require('./__fixtures__/expectedFiles');
+
 // NOTE: this is a tmp integration test to easify development
 // we probably do not want to run this by default in the future
 // (only on CI maybe)
@@ -39,133 +41,9 @@ describe('getPageImages()', () => {
     'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
     'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
   ];
-  const expectedFiles = [
-    {
-      title: 'Datei:Baumeister-Königsberg.JPG',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG',
-      fileSize: 357387,
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG',
-      thumbnail: {
-        height: 400,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:Commons-logo.svg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Commons-logo.svg',
-      fileSize: 932,
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg',
-      thumbnail: {
-        height: 403,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:DEU Königsberg COA.svg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg',
-      fileSize: 38875,
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg',
-      thumbnail: {
-        height: 346,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:Germany adm location map.svg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg',
-      fileSize: 657974,
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg',
-      thumbnail: {
-        height: 356,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:Karte-HSC-Ex.png',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png',
-      fileSize: 32503,
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png',
-      thumbnail: {
-        height: 254,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:Konigsberg Altstadt-1.jpg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg',
-      fileSize: 78351,
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg',
-      thumbnail: {
-        height: 231,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:Konigsberg Altstadt-2.jpg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg',
-      fileSize: 60336,
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg',
-      thumbnail: {
-        height: 231,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:Königsberg Altershausen.jpg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg',
-      fileSize: 4931020,
-      rawUrl:
-        'https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg',
-      thumbnail: {
-        height: 225,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:Königsberg Bühl.jpg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg',
-      fileSize: 4667382,
-      rawUrl: 'https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg',
-      thumbnail: {
-        height: 225,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg',
-        width: 300,
-      },
-    },
-    {
-      title: 'Datei:Königsberg Dörflis.jpg',
-      descriptionUrl: 'https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg',
-      fileSize: 4670674,
-      rawUrl:
-        'https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg',
-      thumbnail: {
-        height: 400,
-        rawUrl:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg',
-        width: 300,
-      },
-    },
-  ];
 
   urls.forEach(url => {
-    it(`when requesting files for "${url}"`, async () => {
+    it(`when requesting files for '${url}'`, async () => {
       const response = await service.getPageImages(url);
       expect(response).toEqual(expectedFiles);
     });

--- a/services/files.js
+++ b/services/files.js
@@ -3,9 +3,15 @@ const assert = require('assert');
 const parseWikiUrl = require('./util/parseWikiUrl');
 const errors = require('./util/errors');
 
+// unescape URL-escaped characters
+function formatTitle(title) {
+  return decodeURI(title.trim());
+}
+
 async function getImageTitles({ client, title, wikiUrl }) {
+  const formattedTitle = formatTitle(title);
   const params = { imlimit: 500 };
-  const response = await client.getResultsFromApi([title], 'images', wikiUrl, params);
+  const response = await client.getResultsFromApi([formattedTitle], 'images', wikiUrl, params);
   assert.ok(response.pages, errors.emptyResponse);
   const pages = Object.values(response.pages);
   assert.ok(pages.length === 1);
@@ -29,7 +35,7 @@ function formatImageInfo(page) {
   return { title, descriptionUrl, rawUrl, fileSize, thumbnail };
 }
 
-async function getImageUrls({ client, titles, wikiUrl }) {
+async function getImageInfos({ client, titles, wikiUrl }) {
   const params = { iiprop: 'url|size', iiurlwidth: 300 };
   const { pages } = await client.getResultsFromApi(titles, 'imageinfo', wikiUrl, params);
   assert.ok(pages, errors.emptyResponse);
@@ -48,7 +54,7 @@ class Files {
     const titles = await getImageTitles({ client, title, wikiUrl });
     if (titles.length === 0) return [];
 
-    return getImageUrls({ client, titles, wikiUrl });
+    return getImageInfos({ client, titles, wikiUrl });
   }
 }
 

--- a/services/util/parseWikiUrl.js
+++ b/services/util/parseWikiUrl.js
@@ -1,6 +1,7 @@
 const errors = require('./errors');
 
 const wikipediaRegExp = /([-a-z]{2,})(\.m)?\.wikipedia\.org\//i;
+const commonsRegExp = /commons(\.m)?\.wikimedia\.org\/w(iki)\/?/i;
 const uploadRegExp = /upload.wikimedia\.org\/wikipedia\/([-a-z]{2,})\//i;
 
 const namePrefixes = ['#mediaviewer/', '#/media/', 'wiki/'];
@@ -25,6 +26,12 @@ function extractName(url) {
   return checks.find(name => !!name);
 }
 
+function splitCommonsUrl(url) {
+  const wikiUrl = 'https://commons.wikimedia.org/';
+  const title = extractName(url);
+  return { title, wikiUrl };
+}
+
 function splitUploadUrl(url) {
   const matches = url.match(uploadRegExp);
   const domain = matches[1] === 'commons' ? 'wikimedia' : 'wikipedia';
@@ -43,6 +50,9 @@ function splitWikipediaUrl(url) {
 }
 
 function parse(url) {
+  if (commonsRegExp.test(url)) {
+    return splitCommonsUrl(url);
+  }
   if (uploadRegExp.test(url)) {
     return splitUploadUrl(url);
   }

--- a/services/util/parseWikiUrl.js
+++ b/services/util/parseWikiUrl.js
@@ -1,7 +1,7 @@
 const errors = require('./errors');
 
 const wikipediaRegExp = /([-a-z]{2,})(\.m)?\.wikipedia\.org\//i;
-const commonsRegExp = /commons(\.m)?\.wikimedia\.org\/w(iki)\/?/i;
+const commonsRegExp = /commons(\.m)?\.wikimedia\.org\/w(iki)?\/?/i;
 const uploadRegExp = /upload.wikimedia\.org\/wikipedia\/([-a-z]{2,})\//i;
 
 const namePrefixes = ['#mediaviewer/', '#/media/', 'wiki/'];

--- a/services/util/parseWikiUrl.test.js
+++ b/services/util/parseWikiUrl.test.js
@@ -69,6 +69,14 @@ const cases = [
     },
   },
   {
+    name: 'upload url without protocol prefix',
+    url: 'upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
+    expected: {
+      title: 'File:Helene_Fischer_2010.jpg',
+      wikiUrl: 'https://commons.wikimedia.org/',
+    },
+  },
+  {
     name: 'upload url thumbnail',
     url:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',

--- a/services/util/parseWikiUrl.test.js
+++ b/services/util/parseWikiUrl.test.js
@@ -77,6 +77,14 @@ const cases = [
       wikiUrl: 'https://commons.wikimedia.org/',
     },
   },
+  {
+    name: 'commons thumbnail',
+    url: 'https://commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+    expected: {
+      title: 'File:Helene_Fischer_2010.jpg',
+      wikiUrl: 'https://commons.wikimedia.org/',
+    },
+  },
 ];
 
 describe('parse()', () => {

--- a/services/util/serializers.test.js
+++ b/services/util/serializers.test.js
@@ -43,7 +43,7 @@ describe('attribution()', () => {
     license,
     fileInfo: {
       rawUrl: 'file_url',
-      title: 'file_title',
+      normalizedTitle: 'file_title',
       artistHtml: 'artist',
     },
   });


### PR DESCRIPTION
Collecting all input URLS/identifiers from our specification PDF in a huge integration test to compare our fileData service against known inputs and see how it behaves.