### PR TITLE
Update number of templates to be returned from the API

### DIFF
--- a/services/licenses.js
+++ b/services/licenses.js
@@ -16,7 +16,7 @@ function formatPageTemplateTitles(response) {
 }
 
 async function getPageTemplates({ client, title, wikiUrl }) {
-  const params = { tlnamespace: 10, tllimit: 100 };
+  const params = { tlnamespace: 10, tllimit: 500 };
   const response = await client.getResultsFromApi([title], 'templates', wikiUrl, params);
   return formatPageTemplateTitles(response);
 }

--- a/services/licenses.test.js
+++ b/services/licenses.test.js
@@ -37,7 +37,7 @@ describe('Licenses', () => {
 
       expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'templates', wikiUrl, {
         tlnamespace: 10,
-        tllimit: 100,
+        tllimit: 500,
       });
       expect(licenseStore.match).toHaveBeenCalledWith(normalizedTemplates);
       expect(license).toEqual(licenseMock);


### PR DESCRIPTION
This updates the number of templates to be returned from the API to 500,
which is the maximum allowed value. See the documentation:
https://www.mediawiki.org/wiki/API:Templates for the exact values that
are allowed.

This is a quick-fix before actually implementing paging on the API
responses.

☝️ this is simply the commit message..

Note: This is a bit in the direction of implementing [paging of responses](https://ora.pm/project/59434/kanban/task/738834).