### PR TITLE
Update number of images returned per request

### DIFF
--- a/services/files.js
+++ b/services/files.js
@@ -4,7 +4,8 @@ const parseWikiUrl = require('./util/parseWikiUrl');
 const errors = require('./util/errors');
 
 async function getImageTitles({ client, title, wikiUrl }) {
-  const response = await client.getResultsFromApi([title], 'images', wikiUrl);
+  const params = { imlimit: 500 };
+  const response = await client.getResultsFromApi([title], 'images', wikiUrl, params);
   assert.ok(response.pages, errors.emptyResponse);
   const pages = Object.values(response.pages);
   assert.ok(pages.length === 1);

--- a/services/files.test.js
+++ b/services/files.test.js
@@ -36,7 +36,9 @@ describe('Files', () => {
         const service = new Files({ client });
         const files = await service.getPageImages(url);
 
-        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl);
+        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl, {
+          imlimit: 500,
+        });
         expect(client.getResultsFromApi).toHaveBeenCalledWith(
           ['File:Graphic 01.jpg', 'File:logo.svg'],
           'imageinfo',
@@ -52,7 +54,9 @@ describe('Files', () => {
         const service = new Files({ client });
         const files = await service.getPageImages(url);
 
-        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl);
+        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl, {
+          imlimit: 500,
+        });
         expect(files).toEqual([]);
       });
 
@@ -64,7 +68,9 @@ describe('Files', () => {
         const service = new Files({ client });
         const files = await service.getPageImages(url);
 
-        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl);
+        expect(client.getResultsFromApi).toHaveBeenCalledWith([title], 'images', wikiUrl, {
+          imlimit: 500,
+        });
         expect(client.getResultsFromApi).toHaveBeenCalledWith(
           ['File:Graphic 01.jpg', 'File:logo.svg'],
           'imageinfo',


### PR DESCRIPTION
This sets the param for the number of images the API returns for an
article to the max. value of 500.