### PR TITLE
[#43] Investigate licenses endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install: yarn install
 script:
   # Run linting and execute tests
   - yarn lint
-  - yarn test
+  - yarn sequentialtest
   # Set up environment
   - cp .env.test .env
   # Ensure generated API specification is up-to-date

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -214,6 +214,18 @@ paths:
       produces:
         - application/json
       responses:
+        '422':
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/UnprocessableEntityErrorResponse'
+        '500':
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+        '503':
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/ServiceUnavailableErrorResponse'
         default:
           description: ''
           schema:
@@ -233,10 +245,6 @@ paths:
       produces:
         - application/json
       responses:
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/BadRequestErrorResponse'
         '422':
           description: Unprocessable Entity
           schema:
@@ -300,6 +308,10 @@ paths:
       produces:
         - application/json
       responses:
+        '500':
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/InternalServerError'
         default:
           description: ''
           schema:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "console": "node --experimental-repl-await console.js",
     "lint": "eslint --ignore-path .gitignore . scripts/*",
     "test": "jest",
-    "debugtest": "yarn test --runInBand --detectOpenHandles --forceExit",
+    "sequentialtest": "yarn test --runInBand --detectOpenHandles --forceExit",
+    "debugtest": "yarn sequentialtest",
     "apidoc": "scripts/gen-apidoc > openapi.yaml"
   },
   "engines": {

--- a/routes/fileinfo.integration.test.js
+++ b/routes/fileinfo.integration.test.js
@@ -8,10 +8,6 @@ const Licenses = require('../services/licenses');
 const licenseData = require('../config/licenses/licenses');
 const portReferences = require('../config/licenses/portReferences');
 
-// NOTE: this is a temporary integration test to easify development
-// We probably do not always want to run this as part of the normal test suite
-// since this is hitting actual Wikipedia and Wikimedia APIs.
-// We could consider running it only on CI or introduce a JS-equivalent to VCR
 describe('fileinfo routes', () => {
   beforeAll(() => {
     startRecording('routes/fileinfo');
@@ -20,6 +16,7 @@ describe('fileinfo routes', () => {
   afterAll(async () => {
     await stopRecording();
   });
+
   let context;
 
   const client = new Client();

--- a/routes/fileinfo.js
+++ b/routes/fileinfo.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 
 const errors = require('../services/util/errors');
+const definitions = require('./__swagger__/definitions');
 const { fileinfo: serialize } = require('../services/util/serializers');
 
 const routes = [];
@@ -47,6 +48,12 @@ routes.push({
     },
     response: {
       schema: responseSchema,
+      status: {
+        404: definitions.errors['404'],
+        422: definitions.errors['422'],
+        500: definitions.errors['500'],
+        503: definitions.errors['503'],
+      },
     },
   },
   handler: async (request, h) => {

--- a/routes/files.js
+++ b/routes/files.js
@@ -56,7 +56,6 @@ routes.push({
     response: {
       schema: Joi.array().items(fileSchema),
       status: {
-        400: definitions.errors['400'],
         422: definitions.errors['422'],
         500: definitions.errors['500'],
         503: definitions.errors['503'],

--- a/routes/licenses.integration.test.js
+++ b/routes/licenses.integration.test.js
@@ -85,14 +85,15 @@ describe('licenses routes', () => {
     it('returns a proper error for invalid license ids', async () => {
       const response = await subject({ licenseId: 'flerb-florb' });
 
-      expect(response.status).toBe(422);
+      expect(response.status).toBe(404);
       expect(response.type).toBe('application/json');
 
+      expect(response.status).toBe(404);
+      expect(response.type).toBe('application/json');
       expect(response.payload).toMatchObject({
-        error: 'Unprocessable Entity',
-        message: 'invalid-license',
-        data: 'flerb-florb',
-        statusCode: 422,
+        error: 'Not Found',
+        message: 'license-not-found',
+        statusCode: 404,
       });
     });
   });

--- a/routes/licenses.integration.test.js
+++ b/routes/licenses.integration.test.js
@@ -1,0 +1,49 @@
+const setup = require('./__helpers__/setup');
+
+const LicenseStore = require('../services/licenseStore');
+const licenseData = require('../config/licenses/licenses');
+const portReferences = require('../config/licenses/portReferences');
+
+// NOTE: this is a temporary integration test to easify development
+// We probably do not always want to run this as part of the normal test suite
+// since this is hitting actual Wikipedia and Wikimedia APIs.
+// We could consider running it only on CI or introduce a JS-equivalent to VCR
+describe('licenses routes', () => {
+  let context;
+
+  const licenseStore = new LicenseStore(licenseData, portReferences);
+  const services = { licenseStore };
+
+  beforeEach(async () => {
+    context = await setup({ services });
+  });
+
+  afterEach(async () => {
+    await context.destroy();
+  });
+
+  describe('GET /licenses', () => {
+    const licenseKeys = ['code', 'name', 'url', 'groups'];
+    function options() {
+      return { url: `/licenses`, method: 'GET' };
+    }
+
+    async function subject() {
+      return context.inject(options());
+    }
+
+    it('returns the list of licenses', async () => {
+      const response = await subject({});
+
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('application/json');
+      response.payload.forEach((license) => {
+        const keys = Object.keys(license);
+        expect(keys).toEqual(expect.arrayContaining(licenseKeys));
+        licenseKeys.forEach((key) => {
+          expect(license[key]).toBeDefined();
+        });
+      });
+    });
+  });
+});

--- a/routes/licenses.integration.test.js
+++ b/routes/licenses.integration.test.js
@@ -4,10 +4,6 @@ const LicenseStore = require('../services/licenseStore');
 const licenseData = require('../config/licenses/licenses');
 const portReferences = require('../config/licenses/portReferences');
 
-// NOTE: this is a temporary integration test to easify development
-// We probably do not always want to run this as part of the normal test suite
-// since this is hitting actual Wikipedia and Wikimedia APIs.
-// We could consider running it only on CI or introduce a JS-equivalent to VCR
 describe('licenses routes', () => {
   let context;
 

--- a/routes/licenses.integration.test.js
+++ b/routes/licenses.integration.test.js
@@ -38,10 +38,10 @@ describe('licenses routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.type).toBe('application/json');
-      response.payload.forEach((license) => {
+      response.payload.forEach(license => {
         const keys = Object.keys(license);
         expect(keys).toEqual(expect.arrayContaining(licenseKeys));
-        licenseKeys.forEach((key) => {
+        licenseKeys.forEach(key => {
           expect(license[key]).toBeDefined();
         });
       });
@@ -50,7 +50,7 @@ describe('licenses routes', () => {
 
   describe('GET /licenses/compatible/{licenseId}', () => {
     const defaults = {
-      licenseId: 'cc-by-sa-3.0-de'
+      licenseId: 'cc-by-sa-3.0-de',
     };
 
     const expectedLicenses = ['cc-by-sa-3.0', 'cc-by-sa-4.0'];
@@ -71,12 +71,14 @@ describe('licenses routes', () => {
       expect(response.type).toBe('application/json');
 
       const licenses = response.payload;
-      expect(licenses.map(license => license.code)).toEqual(expect.arrayContaining(expectedLicenses));
+      expect(licenses.map(license => license.code)).toEqual(
+        expect.arrayContaining(expectedLicenses)
+      );
 
-      licenses.forEach((license) => {
+      licenses.forEach(license => {
         const keys = Object.keys(license);
         expect(keys).toEqual(expect.arrayContaining(licenseKeys));
-        licenseKeys.forEach((key) => {
+        licenseKeys.forEach(key => {
           expect(license[key]).toBeDefined();
         });
       });

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -1,5 +1,4 @@
 const Joi = require('joi');
-const assert = require('assert');
 
 const errors = require('../services/util/errors');
 const { license: serialize } = require('../services/util/serializers');
@@ -9,8 +8,7 @@ const routes = [];
 const licenseSchema = Joi.object({
   code: Joi.string().required(),
   name: Joi.string().required(),
-  url: Joi.string()
-    .required(),
+  url: Joi.string().required(),
   groups: Joi.array()
     .required()
     .items(Joi.string()),

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 
 const errors = require('../services/util/errors');
+const definitions = require('./__swagger__/definitions');
 const { license: serialize } = require('../services/util/serializers');
 
 const routes = [];
@@ -36,6 +37,10 @@ routes.push({
     },
     response: {
       schema: Joi.array().items(licenseSchema),
+      status: {
+        404: definitions.errors['404'],
+        500: definitions.errors['500'],
+      },
     },
   },
   handler: async (request, h) => {

--- a/routes/licenses.js
+++ b/routes/licenses.js
@@ -8,7 +8,6 @@ const licenseSchema = Joi.object({
   code: Joi.string().required(),
   name: Joi.string().required(),
   url: Joi.string()
-    .uri()
     .required(),
   groups: Joi.array()
     .required()

--- a/services/licenseStore.js
+++ b/services/licenseStore.js
@@ -1,4 +1,6 @@
 const License = require('../models/license');
+const errors = require('../services/util/errors');
+const assert = require('assert');
 
 function buildLicense(params) {
   const attributes = {
@@ -82,11 +84,9 @@ class LicenseStore {
   // Returns all compatible licenses for the passed license id.
   compatible(id) {
     const license = this.getLicenseById(id);
-    if (license) {
-      const { compatibility } = license;
-      return compatibility.map(cid => this.getLicenseById(cid));
-    }
-    return [];
+    assert.ok(!!license, errors.licenseNotFound);
+    const { compatibility } = license;
+    return compatibility.map(cid => this.getLicenseById(cid));
   }
 
   // Returns the first license in the list of licenses.js that matches one of the

--- a/services/licenseStore.js
+++ b/services/licenseStore.js
@@ -84,7 +84,7 @@ class LicenseStore {
   // Returns all compatible licenses for the passed license id.
   compatible(id) {
     const license = this.getLicenseById(id);
-    assert.ok(!!license, errors.licenseNotFound);
+    assert.ok(license, errors.licenseNotFound);
     const { compatibility } = license;
     return compatibility.map(cid => this.getLicenseById(cid));
   }

--- a/services/licenseStore.js
+++ b/services/licenseStore.js
@@ -1,6 +1,6 @@
+const assert = require('assert');
 const License = require('../models/license');
 const errors = require('../services/util/errors');
-const assert = require('assert');
 
 function buildLicense(params) {
   const attributes = {

--- a/services/licenseStore.test.js
+++ b/services/licenseStore.test.js
@@ -3,6 +3,7 @@ const License = require('../models/license');
 const licenses = require('../config/licenses/licenses');
 const portReferences = require('../config/licenses/portReferences');
 const compatibleCases = require('./__test__/compatibleCases');
+const errors = require('../services/util/errors');
 
 describe('licenseStore', () => {
   const subject = new LicenseStore(licenses, portReferences);
@@ -146,12 +147,11 @@ describe('licenseStore', () => {
       expect(compatible).toEqual([]);
     });
 
-    it('finds no compatible license for an invalid license id', () => {
-      const compatible = subject.compatible('xx-by-sa-3.0');
-      expect(compatible).toEqual([]);
+    it('throws error for an invalid license id', () => {
+      expect(() => subject.compatible('xx-by-sa-3.0')).toThrow(errors.licenseNotFound);
     });
 
-    it('finds no compatible license for ported licenes', () => {
+    it('finds no compatible license for ported license', () => {
       const compatible = subject.compatible('cc-by-sa-3.0-ported');
       expect(compatible).toEqual([]);
     });


### PR DESCRIPTION
This fixes the malfunctioning `/licenses` endpoints, adds an integration test and also adds error handling to the `/licenses/compatible` endpoint.

The basic reason for the misbehaviour was an `.uri()` response validation in the `/licenses` routes that prevented the results from being rendered. As the source of these served licenses is a static file inside this repo, I simply removed this validation.