### PR TITLE
[#44] Record HTTP request

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,10 @@
     "browser": true,
     "jest": true
   },
+  "globals": {
+    "startRecording": true,
+    "stopRecording": true
+  },
   "extends": [
     "airbnb-base",
     "plugin:prettier/recommended",
@@ -13,6 +17,7 @@
       "error",
       {
         "devDependencies": [
+          "config/jest/*.js",
           "**/*.test.{js,jsx}",
           "**/jest.config.js",
           "**/jest.setup.js",

--- a/README.md
+++ b/README.md
@@ -66,10 +66,18 @@ We use npm scripts for development-related tasks:
 
 You can debug this application with `ndb` by running `yarn debug`. Set break points in the pop-up window and run the test file in the terminal tab of the pop-up window.
 
+In the debug window, run the tests within the supplied terminal using:
+
+```shell
+yarn debugtest
+```
+
+This lets all test run sequentially to avoid concurrency issues.
+
 It can be useful to run tests with the `DEBUG` flag enabled in order to get more information on errors:
 
 ```shell
-DEBUG=true yarn test
+DEBUG=true yarn debugtest
 ```
 
 ## Resources

--- a/__recordings__/routes_1293637783/attribution_1953316374/recording.har
+++ b/__recordings__/routes_1293637783/attribution_1953316374/recording.har
@@ -1,0 +1,834 @@
+{
+  "log": {
+    "_recordingName": "routes/attribution",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "1.4.2"
+    },
+    "entries": [
+      {
+        "_id": "15e1218d52b262d0c076ba166a5fabaf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Foobar.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AFoobar.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 1946,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1946,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"15705443\":{\"pageid\":15705443,\"ns\":6,\"title\":\"File:Foobar.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/3/3a/Foobar.jpg\",\"thumbwidth\":240,\"thumbheight\":28,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/3/3a/Foobar.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Foobar.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15705443\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-07-04 23:31:14\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Foobar\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"CC-Zero|Self-published work|User page images\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Image for parser testing.\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2011-07-04\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/wiki/User:Kaldari\\\" title=\\\"User:Kaldari\\\">Kaldari</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Zero, Public Domain Dedication\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"false\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"http://creativecommons.org/publicdomain/zero/1.0/deed.en\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:09:38 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1946"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1288.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=34426 t=1548162578605167"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "409667622, 550253772, 164575700"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1200,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:09:38.482Z",
+        "time": 218,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 218
+        }
+      },
+      {
+        "_id": "58bdb651f677c30d407d5837d37e6f63",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 276,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "tlnamespace",
+              "value": "10"
+            },
+            {
+              "name": "tllimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "File:Foobar.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "templates"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&tlnamespace=10&tllimit=500&titles=File%3AFoobar.jpg&prop=templates"
+        },
+        "response": {
+          "bodySize": 1145,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1145,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"15705443\":{\"pageid\":15705443,\"ns\":6,\"title\":\"File:Foobar.jpg\",\"templates\":[{\"ns\":10,\"title\":\"Template:Autotranslate\"},{\"ns\":10,\"title\":\"Template:CC-Layout\"},{\"ns\":10,\"title\":\"Template:Cc-zero\"},{\"ns\":10,\"title\":\"Template:Description\"},{\"ns\":10,\"title\":\"Template:Dir\"},{\"ns\":10,\"title\":\"Template:Edit\"},{\"ns\":10,\"title\":\"Template:En\"},{\"ns\":10,\"title\":\"Template:Fr\"},{\"ns\":10,\"title\":\"Template:ISOdate\"},{\"ns\":10,\"title\":\"Template:ISOyear\"},{\"ns\":10,\"title\":\"Template:IfNum\"},{\"ns\":10,\"title\":\"Template:Infobox template tag\"},{\"ns\":10,\"title\":\"Template:Information\"},{\"ns\":10,\"title\":\"Template:Information/author processing\"},{\"ns\":10,\"title\":\"Template:Lang\"},{\"ns\":10,\"title\":\"Template:License template tag\"},{\"ns\":10,\"title\":\"Template:Own\"},{\"ns\":10,\"title\":\"Template:Parse source\"},{\"ns\":10,\"title\":\"Template:Self\"},{\"ns\":10,\"title\":\"Template:Self/is-pd-expired\"},{\"ns\":10,\"title\":\"Template:User page image\"},{\"ns\":10,\"title\":\"Template:User page image/en\"},{\"ns\":10,\"title\":\"Template:User page image/lang\"},{\"ns\":10,\"title\":\"Template:User page image/layout\"},{\"ns\":10,\"title\":\"Template:Years since\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:09:38 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1145"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1228.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=39644 t=1548162578806974"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "352949582, 50376949, 177115357"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1199,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:09:38.711Z",
+        "time": 192,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 192
+        }
+      },
+      {
+        "_id": "15e1218d52b262d0c076ba166a5fabaf",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Foobar.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AFoobar.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 1946,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1946,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"15705443\":{\"pageid\":15705443,\"ns\":6,\"title\":\"File:Foobar.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/3/3a/Foobar.jpg\",\"thumbwidth\":240,\"thumbheight\":28,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/3/3a/Foobar.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Foobar.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15705443\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-07-04 23:31:14\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Foobar\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"CC-Zero|Self-published work|User page images\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Image for parser testing.\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2011-07-04\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/wiki/User:Kaldari\\\" title=\\\"User:Kaldari\\\">Kaldari</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Zero, Public Domain Dedication\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"false\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"http://creativecommons.org/publicdomain/zero/1.0/deed.en\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1276.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=48920 t=1548164660864664"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "416040660, 642518478, 239341768"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:20.732Z",
+        "time": 225,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 225
+        }
+      },
+      {
+        "_id": "15e1218d52b262d0c076ba166a5fabaf",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Foobar.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AFoobar.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 1946,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1946,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"15705443\":{\"pageid\":15705443,\"ns\":6,\"title\":\"File:Foobar.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/3/3a/Foobar.jpg\",\"thumbwidth\":240,\"thumbheight\":28,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/3/3a/Foobar.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Foobar.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15705443\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-07-04 23:31:14\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Foobar\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"CC-Zero|Self-published work|User page images\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Image for parser testing.\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2011-07-04\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/wiki/User:Kaldari\\\" title=\\\"User:Kaldari\\\">Kaldari</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Zero, Public Domain Dedication\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"false\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"http://creativecommons.org/publicdomain/zero/1.0/deed.en\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1279.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=34313 t=1548164661129273"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "432281681, 343444668, 220422631"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:21.020Z",
+        "time": 183,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 183
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__recordings__/routes_1293637783/fileinfo_3571500951/recording.har
+++ b/__recordings__/routes_1293637783/fileinfo_3571500951/recording.har
@@ -1,0 +1,422 @@
+{
+  "log": {
+    "_recordingName": "routes/fileinfo",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "1.4.2"
+    },
+    "entries": [
+      {
+        "_id": "d94bad0ae20346ca118686c0e4c8d595",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 326,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Apple_Lisa2-IMG_1517.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AApple_Lisa2-IMG_1517.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3038,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3038,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Apple_Lisa2-IMG_1517.jpg\",\"to\":\"File:Apple Lisa2-IMG 1517.jpg\"}],\"pages\":{\"17540984\":{\"pageid\":17540984,\"ns\":6,\"title\":\"File:Apple Lisa2-IMG 1517.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Apple_Lisa2-IMG_1517.jpg/300px-Apple_Lisa2-IMG_1517.jpg\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/bc/Apple_Lisa2-IMG_1517.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Apple_Lisa2-IMG_1517.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=17540984\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-12-01 14:17:15\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Apple Lisa2-IMG 1517\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"All media supported by Wikimedia CH|Apple Lisa|CeCILL|Mus\\u00e9e Bolo|Self-published work|Supported by Wikimedia CH\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"The making of this document was supported by <b><a href=\\\"https://meta.wikimedia.org/wiki/Wikimedia_CH\\\" class=\\\"extiw\\\" title=\\\"m:Wikimedia CH\\\">Wikimedia CH</a></b>. <b><small>(<a rel=\\\"nofollow\\\" class=\\\"external text\\\" href=\\\"https://www.wikimedia.ch/\\\">Submit your project!</a>)</small></b><br>\\nFor all the files concerned, please see the category <a href=\\\"//commons.wikimedia.org/wiki/Category:Supported_by_Wikimedia_CH\\\" title=\\\"Category:Supported by Wikimedia CH\\\">Supported by Wikimedia CH</a>.\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/wiki/User:Rama\\\" title=\\\"User:Rama\\\">Rama</a> &amp; Mus\\u00e9e Bolo\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<i>You may select the license of your choice.</i>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 2.0 fr\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 2.0 fr\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Attribution\":{\"value\":\"Photograph by <a href=\\\"//commons.wikimedia.org/wiki/User:Rama\\\" title=\\\"User:Rama\\\">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/2.0/fr/deed.en\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-2.0-fr\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:09:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1315.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=53143 t=1548162580508342"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "426903075, 250722287, 14647812"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:09:40.396Z",
+        "time": 222,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 222
+        }
+      },
+      {
+        "_id": "88c25eeea2c0b3270f0e21a0ce86d1cb",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 290,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "tlnamespace",
+              "value": "10"
+            },
+            {
+              "name": "tllimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "File:Apple_Lisa2-IMG_1517.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "templates"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&tlnamespace=10&tllimit=500&titles=File%3AApple_Lisa2-IMG_1517.jpg&prop=templates"
+        },
+        "response": {
+          "bodySize": 1417,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1417,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Apple_Lisa2-IMG_1517.jpg\",\"to\":\"File:Apple Lisa2-IMG 1517.jpg\"}],\"pages\":{\"17540984\":{\"pageid\":17540984,\"ns\":6,\"title\":\"File:Apple Lisa2-IMG 1517.jpg\",\"templates\":[{\"ns\":10,\"title\":\"Template:Autotranslate\"},{\"ns\":10,\"title\":\"Template:CC-Layout\"},{\"ns\":10,\"title\":\"Template:Cc-by-sa-2.0-fr\"},{\"ns\":10,\"title\":\"Template:Cc-by-sa-layout\"},{\"ns\":10,\"title\":\"Template:Cc-country-flags\"},{\"ns\":10,\"title\":\"Template:CeCILL\"},{\"ns\":10,\"title\":\"Template:Dir\"},{\"ns\":10,\"title\":\"Template:Edit\"},{\"ns\":10,\"title\":\"Template:ISOdate\"},{\"ns\":10,\"title\":\"Template:ISOyear\"},{\"ns\":10,\"title\":\"Template:Infobox template tag\"},{\"ns\":10,\"title\":\"Template:Information\"},{\"ns\":10,\"title\":\"Template:Information/author processing\"},{\"ns\":10,\"title\":\"Template:Lang\"},{\"ns\":10,\"title\":\"Template:LangSwitch\"},{\"ns\":10,\"title\":\"Template:Langswitch\"},{\"ns\":10,\"title\":\"Template:License template tag\"},{\"ns\":10,\"title\":\"Template:Other License-Layout\"},{\"ns\":10,\"title\":\"Template:Own\"},{\"ns\":10,\"title\":\"Template:Parse source\"},{\"ns\":10,\"title\":\"Template:Self\"},{\"ns\":10,\"title\":\"Template:Self/is-pd-expired\"},{\"ns\":10,\"title\":\"Template:Supported by Wikimedia CH\"},{\"ns\":10,\"title\":\"Template:Supported by Wikimedia CH/en\"},{\"ns\":10,\"title\":\"Template:Supported by Wikimedia CH/lang\"},{\"ns\":10,\"title\":\"Template:Supported by Wikimedia CH/layout\"},{\"ns\":10,\"title\":\"Template:Years since\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:09:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1417"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1287.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=30202 t=1548162580717453"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "907769900, 340324814, 14647831"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1089 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1199,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:09:40.624Z",
+        "time": 180,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 180
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__recordings__/services_3647643189/fileData-getFileData-_687440956/recording.har
+++ b/__recordings__/services_3647643189/fileData-getFileData-_687440956/recording.har
@@ -1,0 +1,14990 @@
+{
+  "log": {
+    "_recordingName": "services/fileData.getFileData()",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "1.4.2"
+    },
+    "entries": [
+      {
+        "_id": "893ecd4e8a8bd012de5a0abcd83d99dc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 310,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=K%C3%B6nigsberg_in_Bayern&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 193,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 193,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\"}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:39:43 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "193"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1287.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=27336 t=1548164383564975"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "352809119, 100176330, 207122651"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1312,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:39:43.453Z",
+        "time": 179,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 179
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1278.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=35082 t=1548164661420386"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "59085523, 640850573, 221268609"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:21.311Z",
+        "time": 184,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 184
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1279.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=44765 t=1548164661614904"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "42851359, 116679963, 224478080"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:21.502Z",
+        "time": 197,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 197
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1290.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=34086 t=1548164661825457"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "60788256, 110338115, 227228279"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:21.708Z",
+        "time": 190,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 190
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:22 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1340.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=56875 t=1548164662018309"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "444669785, 109584300, 241895310"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:21.904Z",
+        "time": 211,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 211
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:22 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1233.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=46556 t=1548164662235264"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "114330012, 125002757, 232174567"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:22.121Z",
+        "time": 208,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 208
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:22 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1284.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=67238 t=1548164662450154"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "63473454, 331209463, 243958477"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:22.334Z",
+        "time": 223,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 223
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:22 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1316.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=35387 t=1548164662675784"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "408416023, 326858657, 225466396"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:22.563Z",
+        "time": 189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 189
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:22 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1342.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=40469 t=1548164662872786"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "438013100, 335067985, 222645111"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:22.760Z",
+        "time": 195,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 195
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1284.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=47983 t=1548164663074407"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "416210596, 628315417, 216883152"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:22.963Z",
+        "time": 199,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 199
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1277.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=45607 t=1548164663282352"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "42851388, 123465167, 223131990"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:23.168Z",
+        "time": 204,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 204
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 10,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1288.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=41876 t=1548164663489681"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "109811240, 340239896, 231809398"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:23.378Z",
+        "time": 194,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 194
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 11,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1287.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=61036 t=1548164663688486"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "134552005, 143461190, 222514695"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:23.577Z",
+        "time": 212,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 212
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 12,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1278.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=36566 t=1548164663911809"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "115639830, 622263472, 197327500"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:23.795Z",
+        "time": 192,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 192
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 13,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:24 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1343.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=34544 t=1548164664103361"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "140674862, 132122198, 240094260"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:23.993Z",
+        "time": 184,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 184
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 14,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:24 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1230.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=39895 t=1548164664294032"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "416021707, 140485040, 213439330"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:24.182Z",
+        "time": 193,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 193
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 15,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:24 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1340.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=35471 t=1548164664516405"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "428530830, 108668745, 211351261"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:24.381Z",
+        "time": 215,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 215
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 16,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:24 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1341.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=48541 t=1548164664717082"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "53946382, 107033720, 235287320"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:24.602Z",
+        "time": 203,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 203
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 17,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:25 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1287.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=40118 t=1548164664923189"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "374844749, 639803499, 241271747"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:24.810Z",
+        "time": 195,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 195
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 18,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:25 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1276.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=52673 t=1548164665127026"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "42352772, 440082157, 233812082"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:25.010Z",
+        "time": 212,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 212
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 19,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:25 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1278.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=38569 t=1548164665341557"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "421412010, 327384910, 231356711"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:25.227Z",
+        "time": 198,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 198
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 20,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:25 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1316.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=37901 t=1548164665548508"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "53716400, 426144861, 239572194"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:25.432Z",
+        "time": 196,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 196
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 21,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:25 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1312.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=41211 t=1548164665751373"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "434226357, 109158554, 221437375"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:25.634Z",
+        "time": 203,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 203
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 22,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1281.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=51067 t=1548164665956762"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "437008572, 110951602, 231060220"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:25.842Z",
+        "time": 210,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 210
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 23,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1281.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=48189 t=1548164666167834"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "381491186, 126018956, 230537944"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:26.057Z",
+        "time": 201,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 201
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 24,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1281.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=44172 t=1548164666388765"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "82147813, 444989619, 226480058"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1205,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:26.263Z",
+        "time": 212,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 212
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 25,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1221.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=37281 t=1548164666593878"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "421480673, 626223622, 218321222"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:26.480Z",
+        "time": 190,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 190
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 26,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1316.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=41075 t=1548164666786459"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "435064794, 137245211, 209681688"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:26.677Z",
+        "time": 194,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 194
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 27,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1230.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=35461 t=1548164666989473"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "960903583, 340436061, 238883627"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1089 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:26.877Z",
+        "time": 190,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 190
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 28,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1283.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=36376 t=1548164667192778"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "376415349, 121160064, 242812424"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:27.073Z",
+        "time": 197,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 197
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 29,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1286.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=64452 t=1548164667392844"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "386143103, 447243366, 229617431"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:27.276Z",
+        "time": 220,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 220
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 30,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1282.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=47937 t=1548164667615357"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "452986257, 338506180, 238261372"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:27.502Z",
+        "time": 200,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 200
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 31,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1225.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=36654 t=1548164667819670"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "973835994, 119728664, 231682088"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1089 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:27.708Z",
+        "time": 187,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 187
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 32,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1339.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=43932 t=1548164668013124"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "449384508, 344165951, 225230549"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:27.900Z",
+        "time": 197,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 197
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 33,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1316.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=40726 t=1548164668213473"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "387581831, 325706782, 242648954"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:28.103Z",
+        "time": 191,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 191
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 34,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1314.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=43952 t=1548164668410954"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "441976675, 115569135, 232047877"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:28.299Z",
+        "time": 194,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 194
+        }
+      },
+      {
+        "_id": "795024689cf4ce441417efe2d977a7d1",
+        "_order": 35,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "commons.wikimedia.org"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:Helene_Fischer_2010.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://commons.wikimedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3AHelene_Fischer_2010.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 2218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2218,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:Helene_Fischer_2010.jpg\",\"to\":\"File:Helene Fischer 2010.jpg\"}],\"pages\":{\"15382769\":{\"pageid\":15382769,\"ns\":6,\"title\":\"File:Helene Fischer 2010.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/214px-Helene_Fischer_2010.jpg\",\"thumbwidth\":214,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=15382769\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-06-02 22:16:54\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"Helene Fischer 2010\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Helene Fischer|Self-published work\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"Helene Fischer auf Tournee 2010\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"2010-09-23\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<span class=\\\"int-own-work\\\" lang=\\\"en\\\">Own work</span>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<a href=\\\"//commons.wikimedia.org/w/index.php?title=User:Fleyx24&amp;action=edit&amp;redlink=1\\\" class=\\\"new\\\" title=\\\"User:Fleyx24 (page does not exist)\\\">Fleyx24</a>\",\"source\":\"commons-desc-page\"},\"LicenseShortName\":{\"value\":\"CC BY-SA 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Creative Commons Attribution-Share Alike 3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"AttributionRequired\":{\"value\":\"true\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"https://creativecommons.org/licenses/by-sa/3.0\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"License\":{\"value\":\"cc-by-sa-3.0\",\"source\":\"commons-templates\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikimedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1226.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://commons.wikimedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=39255 t=1548164668610155"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "343957615, 338506195, 208171607"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikimedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1206,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:28.499Z",
+        "time": 188,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 188
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1282.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=45147 t=1548164668834664"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "385552876, 122567076, 238555326"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:28.696Z",
+        "time": 224,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 224
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1276.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=43024 t=1548164669044149"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "359424730, 110467860, 232731299"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:28.926Z",
+        "time": 200,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 200
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1342.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=62685 t=1548164669242703"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "359883084, 333794962, 240258377"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:29.133Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1317.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=53631 t=1548164669491259"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "367284091, 424869692, 228179918"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:29.353Z",
+        "time": 234,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 234
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1276.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=49682 t=1548164669711046"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "409466439, 113345324, 220127281"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:29.592Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1290.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=37321 t=1548164669922538"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "109058709, 124448299, 227391586"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:29.810Z",
+        "time": 189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 189
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1345.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=41108 t=1548164670120401"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "975015180, 134691793, 213439523"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1089 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:30.006Z",
+        "time": 194,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 194
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3172"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1279.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=45587 t=1548164670319384"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "420003858, 338012932, 235875050"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1313,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:30.207Z",
+        "time": 198,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 198
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1227.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=38167 t=1548164670523777"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "106330067, 123191938, 203389766"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:30.410Z",
+        "time": 191,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 191
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1312.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=40544 t=1548164670725209"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "57120126, 441914383, 221105134"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:30.609Z",
+        "time": 201,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 201
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 10,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1312.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=60363 t=1548164670927792"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "118345900, 120246725, 231093696"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:30.816Z",
+        "time": 212,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 212
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 11,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1341.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=45630 t=1548164671148266"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "49197737, 108932268, 223694194"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:31.034Z",
+        "time": 199,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 199
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 12,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1344.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=55324 t=1548164671353609"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "82147856, 111873434, 234171678"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:31.238Z",
+        "time": 209,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 209
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 13,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1278.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=38042 t=1548164671565798"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "437881147, 434523567, 237607248"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:31.452Z",
+        "time": 191,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 191
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 14,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1231.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=60331 t=1548164671765052"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "356936267, 643958324, 239669236"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:31.649Z",
+        "time": 216,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 216
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 15,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1339.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=62860 t=1548164671980836"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "426456051, 122386849, 218551940"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:31.871Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 16,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1279.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=42174 t=1548164672199032"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "43301801, 328981484, 222022935"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:32.089Z",
+        "time": 195,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 195
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 17,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1347.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=40596 t=1548164672406414"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "389252793, 98987449, 239146464"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:32.290Z",
+        "time": 196,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 196
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 18,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1285.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=43911 t=1548164672604503"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "434226477, 345508066, 218160154"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:32.492Z",
+        "time": 195,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 195
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 19,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1229.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=39497 t=1548164672803246"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "974622624, 98855568, 241108118"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1089 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:32.692Z",
+        "time": 189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 189
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 20,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1289.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=40817 t=1548164672997279"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "101824660, 122307658, 206172586"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:32.886Z",
+        "time": 191,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 191
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 21,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1225.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=52216 t=1548164673199078"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "423094423, 135149545, 231414900"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:33.083Z",
+        "time": 212,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 212
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 22,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1289.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=49967 t=1548164673411522"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "136320186, 332160932, 236170068"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:33.300Z",
+        "time": 201,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 201
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 23,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1346.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=43356 t=1548164673619536"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "135370721, 429880001, 238195514"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:33.507Z",
+        "time": 196,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 196
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 24,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1312.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=40314 t=1548164673821666"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "107584581, 438544874, 237966126"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:33.708Z",
+        "time": 193,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 193
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 25,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1279.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=53018 t=1548164674019330"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "447846011, 624360151, 236039973"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:33.907Z",
+        "time": 206,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 206
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 26,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1346.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=48317 t=1548164674229871"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "114134369, 132188405, 238520609"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:34.119Z",
+        "time": 198,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 198
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 27,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1348.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=65001 t=1548164674434403"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "968565265, 134857478, 243008791"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1089 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:34.323Z",
+        "time": 216,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 216
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 28,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1347.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=51200 t=1548164674660143"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "46873565, 436173321, 241272140"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:34.544Z",
+        "time": 210,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 210
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 29,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1343.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=46062 t=1548164674875327"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "364435029, 122077572, 230010283"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:34.760Z",
+        "time": 203,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 203
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 30,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1222.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=43306 t=1548164675087420"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "371801749, 636665106, 240127489"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:34.968Z",
+        "time": 202,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 202
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 31,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1315.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=46847 t=1548164675290091"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "448925831, 342496550, 243663998"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:35.175Z",
+        "time": 200,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 200
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 32,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1342.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=44756 t=1548164675492689"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "358152312, 633489428, 221041359"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:35.380Z",
+        "time": 196,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 196
+        }
+      },
+      {
+        "_id": "27ce80ec03ab88cec1781f5d57c68fe3",
+        "_order": 33,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|extmetadata|mediatype"
+            },
+            {
+              "name": "iilimit",
+              "value": "1"
+            },
+            {
+              "name": "iiurlheight",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Cextmetadata%7Cmediatype&iilimit=1&iiurlheight=300&titles=File%3A1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 3172,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 3172,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"File:1_FC_Bamberg_-_1_FC_N\\u00fcrnberg_1901.jpg\",\"to\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\"}],\"pages\":{\"6021018\":{\"pageid\":6021018,\"ns\":6,\"title\":\"Datei:1 FC Bamberg - 1 FC N\\u00fcrnberg 1901.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/479px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"thumbwidth\":479,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=6021018\",\"extmetadata\":{\"DateTime\":{\"value\":\"2011-02-19 19:29:30\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"ObjectName\":{\"value\":\"1 FC Bamberg - 1 FC N\\u00fcrnberg 1901\",\"source\":\"mediawiki-metadata\",\"hidden\":\"\"},\"CommonsMetadataExtension\":{\"value\":1.2,\"source\":\"extension\",\"hidden\":\"\"},\"Categories\":{\"value\":\"Datei:Bamberg|Datei:Gemeinfrei (100 Jahre)|Datei:NoCommons\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"Assessments\":{\"value\":\"\",\"source\":\"commons-categories\",\"hidden\":\"\"},\"ImageDescription\":{\"value\":\"<p>Die Fu\\u00dfballmannschaften des <a href=\\\"//de.wikipedia.org/wiki/1._FC_Bamberg\\\" class=\\\"mw-redirect\\\" title=\\\"1. FC Bamberg\\\">1. FC Bamberg</a> und des <a href=\\\"//de.wikipedia.org/wiki/1._FC_N%C3%BCrnberg\\\" title=\\\"1. FC N\\u00fcrnberg\\\">1. FC N\\u00fcrnberg</a> anl\\u00e4sslich der ersten Begegnung der beiden Klubs am 29. September 1901. <br>Die N\\u00fcrnberger (gestreifte Hemden, von links: oben: Krause, Neundorf; Mitte: Schmidt, Felsenstein, Haas, Hofmann, Ott; vorn: W. Heinz, D\\u00fcrbeck, Torwart Eckardt, Chr. Heinz\\n</p>\",\"source\":\"commons-desc-page\"},\"Credit\":{\"value\":\"<p>Scan aus <i>Die Legende vom Club. Die Geschichte des 1. FC N\\u00fcrnberg</i>, Verlag Die Werkstatt, G\\u00f6ttingen 2006, Seite 14\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Artist\":{\"value\":\"<p>unbekannt\\n</p>\",\"source\":\"commons-desc-page\"},\"DateTimeOriginal\":{\"value\":\"<p>1901\\n</p>\",\"source\":\"commons-desc-page\"},\"Permission\":{\"value\":\"<p>Schutzfrist abgelaufen\\n</p>\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseShortName\":{\"value\":\"PD-alt-100\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"UsageTerms\":{\"value\":\"Die <a href=\\\"//de.wikipedia.org/wiki/Regelschutzfrist\\\" title=\\\"Regelschutzfrist\\\">Regelschutzfrist</a> f\\u00fcr das von dieser Datei gezeigte Werk ist nach den Ma\\u00dfst\\u00e4ben des deutschen, \\u00f6sterreichischen und schweizerischen Urheberrechts (70 Jahre nach dem Tod des Urhebers) vermutlich abgelaufen. Es ist daher vermutlich <b><a href=\\\"//de.wikipedia.org/wiki/Gemeinfreiheit\\\" title=\\\"Gemeinfreiheit\\\">gemeinfrei</a></b>.\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"LicenseUrl\":{\"value\":\"//de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Copyrighted\":{\"value\":\"True\",\"source\":\"commons-desc-page\",\"hidden\":\"\"},\"Restrictions\":{\"value\":\"\",\"source\":\"commons-desc-page\",\"hidden\":\"\"}},\"mediatype\":\"BITMAP\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:44:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1289.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=38708 t=1548164675693219"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "452921085, 123647251, 242714471"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:44:35.581Z",
+        "time": 189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 189
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/__recordings__/services_3647643189/files-getPageImages-_3418239816/recording.har
+++ b/__recordings__/services_3647643189/files-getPageImages-_3418239816/recording.har
@@ -1,0 +1,10094 @@
+{
+  "log": {
+    "_recordingName": "services/files.getPageImages()",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "1.4.2"
+    },
+    "entries": [
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:10:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1346.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=32775 t=1548162629127894"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "345098042, 250564135, 174660282"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:10:29.021Z",
+        "time": 193,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 193
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:10:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1285.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=158509 t=1548162629317622"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "351672647, 48254459, 163333666"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:10:29.220Z",
+        "time": 338,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 338
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1222.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=37857 t=1548163348383399"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "330920264, 78626476, 184176804"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:28.257Z",
+        "time": 215,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 215
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1289.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=146239 t=1548163348580510"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "344477075, 48418704, 189286464"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:28.479Z",
+        "time": 317,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 317
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1317.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=43704 t=1548163348909696"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "347401788, 289051565, 189252699"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:28.804Z",
+        "time": 198,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 198
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 2,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1280.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=280914 t=1548163349111132"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "330397952, 290196471, 196089038"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1320,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:29.008Z",
+        "time": 455,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 455
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1285.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=26600 t=1548163349570573"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "363862464, 290949559, 190659595"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:29.470Z",
+        "time": 177,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 177
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 3,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:29 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1284.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=139238 t=1548163349753587"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "355055061, 588514571, 184633181"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1320,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:29.653Z",
+        "time": 313,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 313
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1227.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=29206 t=1548163350072769"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "114370108, 78362413, 197791267"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:29.973Z",
+        "time": 177,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 177
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 4,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1235.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=192830 t=1548163350260191"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "368609238, 55714709, 182013648"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:30.156Z",
+        "time": 396,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 396
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1317.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=40606 t=1548163350666104"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "78792891, 52737760, 190857014"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1317,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:30.565Z",
+        "time": 192,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 192
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 5,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1345.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=283127 t=1548163350868062"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "418321746, 50214199, 199790313"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:30.763Z",
+        "time": 464,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 464
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1286.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=36157 t=1548163351337055"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "361474999, 77727088, 187650587"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:31.234Z",
+        "time": 214,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 214
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 6,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1288.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=142827 t=1548163351557092"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "367496163, 85859253, 180669186"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:31.453Z",
+        "time": 316,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 316
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1284.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=24544 t=1548163351879386"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "330954081, 383527627, 173308727"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:31.778Z",
+        "time": 173,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 173
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 7,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1348.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=269441 t=1548163352059283"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "328332359, 70266323, 177141088"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:31.957Z",
+        "time": 441,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 441
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1228.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=34630 t=1548163352506552"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "103206311, 55749328, 176521091"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:32.407Z",
+        "time": 182,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 182
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 8,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1284.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=179196 t=1548163352698276"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "405155824, 72167152, 183592680"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:32.594Z",
+        "time": 362,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 362
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1225.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=28276 t=1548163353066630"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "364123656, 373943626, 193829701"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:32.962Z",
+        "time": 179,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 179
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 9,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1279.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=167192 t=1548163353250529"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "346932965, 588776779, 177042200"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1320,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:33.146Z",
+        "time": 352,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 352
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 10,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1290.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=26970 t=1548163353608158"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "110571148, 283195875, 186759469"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1083 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:33.504Z",
+        "time": 179,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 179
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 10,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1289.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=129761 t=1548163353800102"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "417177004, 58069149, 199168821"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:33.688Z",
+        "time": 310,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 310
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 11,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1282.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=38242 t=1548163354110098"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "88909561, 387945698, 188759279"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:34.004Z",
+        "time": 192,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 192
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 11,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1283.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=149027 t=1548163354305458"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "413325100, 289543260, 190463333"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1320,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:34.202Z",
+        "time": 322,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 322
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 12,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1221.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=25714 t=1548163354631494"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "29471364, 287973340, 176223260"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:34.533Z",
+        "time": 172,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 172
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 12,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1346.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=160281 t=1548163354811303"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "6973934, 61112678, 176810051"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1317,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:34.710Z",
+        "time": 357,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 357
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 13,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1223.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=33104 t=1548163355175087"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "423854551, 61996188, 197169165"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1087 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:35.073Z",
+        "time": 186,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 186
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 13,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1283.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=145991 t=1548163355366489"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "94543561, 82033341, 178607270"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:35.264Z",
+        "time": 320,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 320
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 14,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1290.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=32026 t=1548163355692727"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "27160616, 270586474, 188792654"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:35.591Z",
+        "time": 183,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 183
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 14,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1289.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=159942 t=1548163355888034"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "346671942, 48650545, 187190280"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:35.780Z",
+        "time": 336,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 336
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 15,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1346.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=38198 t=1548163356226048"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "45549113, 274098648, 189382873"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:36.123Z",
+        "time": 190,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 190
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 15,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1342.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=168508 t=1548163356448722"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "36883059, 82063386, 204377706"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:36.318Z",
+        "time": 375,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 375
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 16,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1227.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=25186 t=1548163356804612"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "369886325, 580861822, 191934333"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3030 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:36.700Z",
+        "time": 180,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 180
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 16,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:37 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1231.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=155708 t=1548163356988459"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "46072636, 274067706, 190463520"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:36.885Z",
+        "time": 332,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 332
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 17,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:37 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1312.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=26223 t=1548163357324728"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "34547770, 377181083, 173894905"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:37.224Z",
+        "time": 174,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 174
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 17,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:37 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1281.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=158144 t=1548163357512628"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "419903837, 85991151, 200380142"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:37.404Z",
+        "time": 349,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 349
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 18,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:37 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1223.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=25261 t=1548163357862147"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "8514554, 275236883, 202609180"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1317,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:37.760Z",
+        "time": 174,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 174
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 18,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:38 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1314.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=156823 t=1548163358039618"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "434113815, 46454926, 204312752"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:37.939Z",
+        "time": 331,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 331
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 19,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:38 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1342.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=47516 t=1548163358376045"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "59832012, 64809484, 186238996"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1317,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:38.276Z",
+        "time": 195,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 195
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 19,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:38 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1278.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=162012 t=1548163358579276"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "347042491, 378519949, 190718723"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1320,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:38.475Z",
+        "time": 335,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 335
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 20,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:38 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1344.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=37598 t=1548163358918673"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "347239328, 380454273, 184992452"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1319,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:38.819Z",
+        "time": 184,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 184
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 20,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:39 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1285.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=146946 t=1548163359110501"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "83247641, 57710538, 195826388"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:39.008Z",
+        "time": 322,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 322
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 21,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:39 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1283.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=27939 t=1548163359442326"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "420199995, 60420754, 199037146"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1079 pass, cp3040 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:39.336Z",
+        "time": 182,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 182
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 21,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:39 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1346.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=169043 t=1548163359624753"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "352140210, 388076992, 192784131"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1077 pass, cp3042 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1320,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:39.523Z",
+        "time": 342,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 342
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 22,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1279.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=29248 t=1548163359973768"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "90743335, 69592942, 204867233"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1081 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1317,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:39.871Z",
+        "time": 178,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 178
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 22,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1342.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=165277 t=1548163360160266"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "416584619, 283816825, 192784163"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1085 pass, cp3033 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1320,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:40.055Z",
+        "time": 346,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 346
+        }
+      },
+      {
+        "_id": "6ddb01d4efeac889a9bc10b7e6ee8813",
+        "_order": 23,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 256,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "imlimit",
+              "value": "500"
+            },
+            {
+              "name": "titles",
+              "value": "Königsberg_in_Bayern"
+            },
+            {
+              "name": "prop",
+              "value": "images"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&imlimit=500&titles=K%C3%B6nigsberg_in_Bayern&prop=images"
+        },
+        "response": {
+          "bodySize": 1887,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1887,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"normalized\":[{\"from\":\"K\\u00f6nigsberg_in_Bayern\",\"to\":\"K\\u00f6nigsberg in Bayern\"}],\"pages\":{\"21330\":{\"pageid\":21330,\"ns\":0,\"title\":\"K\\u00f6nigsberg in Bayern\",\"images\":[{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\"},{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\"},{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\"},{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\"},{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\"},{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\"},{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\"},{\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\"},{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Reddot.svg\"},{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\"},{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\"},{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\"},{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\"},{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\"},{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1282.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=38376 t=1548163360507004"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "937414026, 56373789, 161638530"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1089 pass, cp3041 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:40.407Z",
+        "time": 187,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 187
+        }
+      },
+      {
+        "_id": "0f31d9d5fdc8d98c076906f7fcfa6192",
+        "_order": 23,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.18.0"
+            },
+            {
+              "name": "host",
+              "value": "de.wikipedia.org"
+            }
+          ],
+          "headersSize": 1526,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8"
+          },
+          "queryString": [
+            {
+              "name": "action",
+              "value": "query"
+            },
+            {
+              "name": "format",
+              "value": "json"
+            },
+            {
+              "name": "iiprop",
+              "value": "url|size"
+            },
+            {
+              "name": "iiurlwidth",
+              "value": "300"
+            },
+            {
+              "name": "titles",
+              "value": "Datei:Baumeister-Königsberg.JPG|Datei:Commons-logo.svg|Datei:DEU Königsberg COA.svg|Datei:Germany adm location map.svg|Datei:Karte-HSC-Ex.png|Datei:Konigsberg Altstadt-1.jpg|Datei:Konigsberg Altstadt-2.jpg|Datei:Königsberg Altershausen.jpg|Datei:Königsberg Bühl.jpg|Datei:Königsberg Dörflis.jpg|Datei:Königsberg Hellingen.jpg|Datei:Königsberg Hofstetten.jpg|Datei:Königsberg Junkersdorf.jpg|Datei:Königsberg Kottenbrunn.jpg|Datei:Königsberg Köslau.jpg|Datei:Königsberg Römershofen.jpg|Datei:Königsberg Unfinden.jpg|Datei:Königsberg in Bayern in HAS.svg|Datei:Luftbild-koenigsberg-bayern.jpg|Datei:Luftkurort Königsberg.jpg|Datei:Marienkirche-waechterturm-koenigsberg.jpg|Datei:Marienstrasse.jpg|Datei:Marktbrunnen-koenigsberg.jpg|Datei:Reddot.svg|Datei:Regiomontanus-Koenigsberg.JPG|Datei:Roland-Koenigsberg.JPG|Datei:Seckendorff-Tafel.JPG|Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG|Datei:Wappen Landkreis Haßberge.svg|Datei:Westansicht-schlossberg-koenigsberg.jpg|Datei:Wikisource-logo.svg"
+            },
+            {
+              "name": "prop",
+              "value": "imageinfo"
+            }
+          ],
+          "url": "https://de.wikipedia.org/w/api.php?action=query&format=json&iiprop=url%7Csize&iiurlwidth=300&titles=Datei%3ABaumeister-K%C3%B6nigsberg.JPG%7CDatei%3ACommons-logo.svg%7CDatei%3ADEU%20K%C3%B6nigsberg%20COA.svg%7CDatei%3AGermany%20adm%20location%20map.svg%7CDatei%3AKarte-HSC-Ex.png%7CDatei%3AKonigsberg%20Altstadt-1.jpg%7CDatei%3AKonigsberg%20Altstadt-2.jpg%7CDatei%3AK%C3%B6nigsberg%20Altershausen.jpg%7CDatei%3AK%C3%B6nigsberg%20B%C3%BChl.jpg%7CDatei%3AK%C3%B6nigsberg%20D%C3%B6rflis.jpg%7CDatei%3AK%C3%B6nigsberg%20Hellingen.jpg%7CDatei%3AK%C3%B6nigsberg%20Hofstetten.jpg%7CDatei%3AK%C3%B6nigsberg%20Junkersdorf.jpg%7CDatei%3AK%C3%B6nigsberg%20Kottenbrunn.jpg%7CDatei%3AK%C3%B6nigsberg%20K%C3%B6slau.jpg%7CDatei%3AK%C3%B6nigsberg%20R%C3%B6mershofen.jpg%7CDatei%3AK%C3%B6nigsberg%20Unfinden.jpg%7CDatei%3AK%C3%B6nigsberg%20in%20Bayern%20in%20HAS.svg%7CDatei%3ALuftbild-koenigsberg-bayern.jpg%7CDatei%3ALuftkurort%20K%C3%B6nigsberg.jpg%7CDatei%3AMarienkirche-waechterturm-koenigsberg.jpg%7CDatei%3AMarienstrasse.jpg%7CDatei%3AMarktbrunnen-koenigsberg.jpg%7CDatei%3AReddot.svg%7CDatei%3ARegiomontanus-Koenigsberg.JPG%7CDatei%3ARoland-Koenigsberg.JPG%7CDatei%3ASeckendorff-Tafel.JPG%7CDatei%3ASendeturm%20Konigsberg%20in%20Bayern13032017%202.JPG%7CDatei%3AWappen%20Landkreis%20Ha%C3%9Fberge.svg%7CDatei%3AWestansicht-schlossberg-koenigsberg.jpg%7CDatei%3AWikisource-logo.svg&prop=imageinfo"
+        },
+        "response": {
+          "bodySize": 18513,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 18513,
+            "text": "{\"batchcomplete\":\"\",\"query\":{\"pages\":{\"-1\":{\"ns\":6,\"title\":\"Datei:Baumeister-K\\u00f6nigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":357387,\"width\":994,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Baumeister-K%C3%B6nigsberg.JPG/300px-Baumeister-K%C3%B6nigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/b8/Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Baumeister-K%C3%B6nigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157178\"}]},\"-2\":{\"ns\":6,\"title\":\"Datei:Commons-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":932,\"width\":1024,\"height\":1376,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/300px-Commons-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":403,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Commons-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Commons-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=317966\"}]},\"-3\":{\"ns\":6,\"title\":\"Datei:DEU K\\u00f6nigsberg COA.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":38875,\"width\":512,\"height\":591,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/DEU_K%C3%B6nigsberg_COA.svg/300px-DEU_K%C3%B6nigsberg_COA.svg.png\",\"thumbwidth\":300,\"thumbheight\":346,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/c/c4/DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:DEU_K%C3%B6nigsberg_COA.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=40081135\"}]},\"-4\":{\"ns\":6,\"title\":\"Datei:Germany adm location map.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":657974,\"width\":1073,\"height\":1272,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Germany_adm_location_map.svg/300px-Germany_adm_location_map.svg.png\",\"thumbwidth\":300,\"thumbheight\":356,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/ed/Germany_adm_location_map.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Germany_adm_location_map.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=35392837\"}]},\"-5\":{\"ns\":6,\"title\":\"Datei:Karte-HSC-Ex.png\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":32503,\"width\":675,\"height\":571,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Karte-HSC-Ex.png/300px-Karte-HSC-Ex.png\",\"thumbwidth\":300,\"thumbheight\":254,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e9/Karte-HSC-Ex.png\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Karte-HSC-Ex.png\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=1825127\"}]},\"-6\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-1.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":78351,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Konigsberg_Altstadt-1.jpg/300px-Konigsberg_Altstadt-1.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/6/6a/Konigsberg_Altstadt-1.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-1.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217305\"}]},\"-7\":{\"ns\":6,\"title\":\"Datei:Konigsberg Altstadt-2.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":60336,\"width\":800,\"height\":615,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Konigsberg_Altstadt-2.jpg/300px-Konigsberg_Altstadt-2.jpg\",\"thumbwidth\":300,\"thumbheight\":231,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/7/71/Konigsberg_Altstadt-2.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Konigsberg_Altstadt-2.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=5217345\"}]},\"-8\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Altershausen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4931020,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/K%C3%B6nigsberg_Altershausen.jpg/300px-K%C3%B6nigsberg_Altershausen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Altershausen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854807\"}]},\"-9\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg B\\u00fchl.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4667382,\"width\":2803,\"height\":2102,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg/300px-K%C3%B6nigsberg_B%C3%BChl.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/5a/K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_B%C3%BChl.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854839\"}]},\"-10\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg D\\u00f6rflis.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4670674,\"width\":2304,\"height\":3072,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg/300px-K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/a/a3/K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_D%C3%B6rflis.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854861\"}]},\"-11\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hellingen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3904181,\"width\":2224,\"height\":2965,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/K%C3%B6nigsberg_Hellingen.jpg/300px-K%C3%B6nigsberg_Hellingen.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hellingen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854876\"}]},\"-12\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Hofstetten.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4420981,\"width\":2890,\"height\":2167,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/K%C3%B6nigsberg_Hofstetten.jpg/300px-K%C3%B6nigsberg_Hofstetten.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Hofstetten.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854884\"}]},\"-13\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Junkersdorf.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3364682,\"width\":2737,\"height\":2052,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/K%C3%B6nigsberg_Junkersdorf.jpg/300px-K%C3%B6nigsberg_Junkersdorf.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/40/K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Junkersdorf.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854894\"}]},\"-14\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Kottenbrunn.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":5019771,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg/300px-K%C3%B6nigsberg_Kottenbrunn.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4b/K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Kottenbrunn.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854918\"}]},\"-15\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg K\\u00f6slau.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4789750,\"width\":3072,\"height\":2304,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg/300px-K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/eb/K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_K%C3%B6slau.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854906\"}]},\"-16\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg R\\u00f6mershofen.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":3634911,\"width\":2732,\"height\":2049,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg/300px-K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/fb/K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_R%C3%B6mershofen.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854932\"}]},\"-17\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg Unfinden.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":4262148,\"width\":2188,\"height\":2917,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/K%C3%B6nigsberg_Unfinden.jpg/300px-K%C3%B6nigsberg_Unfinden.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/8/82/K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_Unfinden.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=21854943\"}]},\"-18\":{\"ns\":6,\"title\":\"Datei:K\\u00f6nigsberg in Bayern in HAS.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":371710,\"width\":567,\"height\":580,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg/300px-K%C3%B6nigsberg_in_Bayern_in_HAS.svg.png\",\"thumbwidth\":300,\"thumbheight\":307,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/2f/K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:K%C3%B6nigsberg_in_Bayern_in_HAS.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=9762999\"}]},\"-19\":{\"ns\":6,\"title\":\"Datei:Luftbild-koenigsberg-bayern.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":661989,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Luftbild-koenigsberg-bayern.jpg/300px-Luftbild-koenigsberg-bayern.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/46/Luftbild-koenigsberg-bayern.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Luftbild-koenigsberg-bayern.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600101\"}]},\"-20\":{\"ns\":6,\"title\":\"Datei:Marienkirche-waechterturm-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":1107053,\"width\":2219,\"height\":2958,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Marienkirche-waechterturm-koenigsberg.jpg/300px-Marienkirche-waechterturm-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9c/Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienkirche-waechterturm-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600134\"}]},\"-21\":{\"ns\":6,\"title\":\"Datei:Marienstrasse.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":174739,\"width\":791,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Marienstrasse.jpg/300px-Marienstrasse.jpg\",\"thumbwidth\":300,\"thumbheight\":265,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f9/Marienstrasse.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marienstrasse.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600239\"}]},\"-22\":{\"ns\":6,\"title\":\"Datei:Marktbrunnen-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":185583,\"width\":627,\"height\":586,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Marktbrunnen-koenigsberg.jpg/300px-Marktbrunnen-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":280,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/9/9a/Marktbrunnen-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Marktbrunnen-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10600212\"}]},\"-23\":{\"ns\":6,\"title\":\"Datei:Reddot.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":430,\"width\":402,\"height\":402,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f1/Reddot.svg/300px-Reddot.svg.png\",\"thumbwidth\":300,\"thumbheight\":300,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/f/f1/Reddot.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Reddot.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=927619\"}]},\"-24\":{\"ns\":6,\"title\":\"Datei:Regiomontanus-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":660842,\"width\":1984,\"height\":1488,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Regiomontanus-Koenigsberg.JPG/300px-Regiomontanus-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/42/Regiomontanus-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Regiomontanus-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157125\"}]},\"-25\":{\"ns\":6,\"title\":\"Datei:Roland-Koenigsberg.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":284295,\"width\":993,\"height\":1324,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Roland-Koenigsberg.JPG/300px-Roland-Koenigsberg.JPG\",\"thumbwidth\":300,\"thumbheight\":400,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/b/be/Roland-Koenigsberg.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Roland-Koenigsberg.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2157000\"}]},\"-26\":{\"ns\":6,\"title\":\"Datei:Seckendorff-Tafel.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":603140,\"width\":1759,\"height\":1173,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Seckendorff-Tafel.JPG/300px-Seckendorff-Tafel.JPG\",\"thumbwidth\":300,\"thumbheight\":200,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/5/57/Seckendorff-Tafel.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Seckendorff-Tafel.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=2156172\"}]},\"-27\":{\"ns\":6,\"title\":\"Datei:Sendeturm Konigsberg in Bayern13032017 2.JPG\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":9568514,\"width\":3372,\"height\":5058,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG/300px-Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"thumbwidth\":300,\"thumbheight\":450,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/e/e1/Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Sendeturm_Konigsberg_in_Bayern13032017_2.JPG\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=57150496\"}]},\"-28\":{\"ns\":6,\"title\":\"Datei:Wappen Landkreis Ha\\u00dfberge.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":95383,\"width\":795,\"height\":871,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg/300px-Wappen_Landkreis_Ha%C3%9Fberge.svg.png\",\"thumbwidth\":300,\"thumbheight\":329,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/2/29/Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wappen_Landkreis_Ha%C3%9Fberge.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=6819048\"}]},\"-29\":{\"ns\":6,\"title\":\"Datei:Westansicht-schlossberg-koenigsberg.jpg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":230508,\"width\":933,\"height\":700,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Westansicht-schlossberg-koenigsberg.jpg/300px-Westansicht-schlossberg-koenigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":225,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/19/Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Westansicht-schlossberg-koenigsberg.jpg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=10597806\"}]},\"-30\":{\"ns\":6,\"title\":\"Datei:Wikisource-logo.svg\",\"missing\":\"\",\"known\":\"\",\"imagerepository\":\"shared\",\"imageinfo\":[{\"size\":16160,\"width\":410,\"height\":430,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Wikisource-logo.svg/300px-Wikisource-logo.svg.png\",\"thumbwidth\":300,\"thumbheight\":315,\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\",\"descriptionurl\":\"https://commons.wikimedia.org/wiki/File:Wikisource-logo.svg\",\"descriptionshorturl\":\"https://commons.wikimedia.org/w/index.php?curid=838446\"}]},\"7903958\":{\"pageid\":7903958,\"ns\":6,\"title\":\"Datei:Luftkurort K\\u00f6nigsberg.jpg\",\"imagerepository\":\"local\",\"imageinfo\":[{\"size\":181752,\"width\":793,\"height\":512,\"thumburl\":\"https://upload.wikimedia.org/wikipedia/de/thumb/9/97/Luftkurort_K%C3%B6nigsberg.jpg/300px-Luftkurort_K%C3%B6nigsberg.jpg\",\"thumbwidth\":300,\"thumbheight\":194,\"url\":\"https://upload.wikimedia.org/wikipedia/de/9/97/Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionurl\":\"https://de.wikipedia.org/wiki/Datei:Luftkurort_K%C3%B6nigsberg.jpg\",\"descriptionshorturl\":\"https://de.wikipedia.org/w/index.php?curid=7903958\"}]}}}}"
+          },
+          "cookies": [
+            {
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "expires": "2019-02-23T12:00:00.000Z",
+              "httpOnly": true,
+              "name": "WMF-Last-Access-Global",
+              "path": "/",
+              "secure": true,
+              "value": "22-Jan-2019"
+            },
+            {
+              "domain": ".wikipedia.org",
+              "name": "GeoIP",
+              "path": "/",
+              "secure": true,
+              "value": "DE:BE:Berlin:52.51:13.36:v4"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 22 Jan 2019 13:22:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "mw1342.eqiad.wmnet"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "HHVM/3.18.6-dev"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"This is not a P3P policy! See https://de.wikipedia.org/wiki/Spezial:CentralAutoLogin/P3P for more info.\""
+            },
+            {
+              "name": "cache-control",
+              "value": "private, must-revalidate, max-age=0"
+            },
+            {
+              "name": "content-disposition",
+              "value": "inline; filename=api-result.json"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "backend-timing",
+              "value": "D=159988 t=1548163360699655"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,X-Seven"
+            },
+            {
+              "name": "x-varnish",
+              "value": "37318872, 69592952, 204508847"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "x-cache",
+              "value": "cp1075 pass, cp3032 pass, cp3033 pass"
+            },
+            {
+              "name": "x-cache-status",
+              "value": "pass"
+            },
+            {
+              "name": "server-timing",
+              "value": "cache;desc=\"pass\""
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=106384710; includeSubDomains; preload"
+            },
+            {
+              "name": "set-cookie",
+              "value": [
+                "WMF-Last-Access=22-Jan-2019;Path=/;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "WMF-Last-Access-Global=22-Jan-2019;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat, 23 Feb 2019 12:00:00 GMT",
+                "GeoIP=DE:BE:Berlin:52.51:13.36:v4; Path=/; secure; Domain=.wikipedia.org"
+              ]
+            },
+            {
+              "name": "x-analytics",
+              "value": "ns=-1;special=Badtitle;https=1;nocookies=1"
+            },
+            {
+              "name": "x-client-ip",
+              "value": "178.19.219.12"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-01-22T13:22:40.599Z",
+        "time": 332,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 332
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/config/jest/vcrNode.js
+++ b/config/jest/vcrNode.js
@@ -1,0 +1,45 @@
+const NodeEnvironment = require('jest-environment-node');
+const { Polly } = require('@pollyjs/core');
+const NodeHttpAdapter = require('@pollyjs/adapter-node-http');
+const FSPersister = require('@pollyjs/persister-fs');
+
+Polly.register(NodeHttpAdapter);
+Polly.register(FSPersister);
+
+let polly = null;
+
+async function stopRecording() {
+  if (polly) {
+    await polly.stop();
+    polly = null;
+  }
+}
+
+function startRecording(recordingName) {
+  if (polly) {
+    throw new Error('a recording is already running');
+  }
+
+  polly = new Polly(recordingName, {
+    adapters: ['node-http'],
+    persister: 'fs',
+    persisterOptions: {
+      fs: {
+        recordingsDir: '__recordings__',
+      },
+    },
+    recordIfMissing: true,
+  });
+
+  return polly;
+}
+
+class VcrNode extends NodeEnvironment {
+  async setup() {
+    await super.setup();
+    this.global.startRecording = startRecording;
+    this.global.stopRecording = stopRecording;
+  }
+}
+
+module.exports = VcrNode;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   globalSetup: '<rootDir>/jest.setup.js',
-  testEnvironment: 'node',
+  testEnvironment: '<rootDir>/config/jest/vcrNode',
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "console": "node --experimental-repl-await console.js",
     "lint": "eslint --ignore-path .gitignore . scripts/*",
     "test": "jest",
+    "debugtest": "yarn test --runInBand --detectOpenHandles --forceExit",
     "apidoc": "scripts/gen-apidoc > openapi.yaml"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "debug": "ndb start.js",
     "console": "node --experimental-repl-await console.js",
     "lint": "eslint --ignore-path .gitignore . scripts/*",
-    "test": "jest --runInBand",
+    "test": "jest",
     "apidoc": "scripts/gen-apidoc > openapi.yaml"
   },
   "engines": {
@@ -38,6 +38,9 @@
     "repl.history": "^0.1.4"
   },
   "devDependencies": {
+    "@pollyjs/adapter-node-http": "^1.4.2",
+    "@pollyjs/core": "^1.4.2",
+    "@pollyjs/persister-fs": "^1.4.2",
     "eslint": "^5.10.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^3.3.0",
@@ -45,6 +48,7 @@
     "eslint-plugin-jest": "^22.1.2",
     "eslint-plugin-prettier": "^3.0.0",
     "jest": "^23.5.0",
+    "jest-environment-node": "^23.4.0",
     "js-yaml": "^3.12.0",
     "ndb": "^1.0.25",
     "nodemon": "^1.18.4",

--- a/routes/attribution.integration.test.js
+++ b/routes/attribution.integration.test.js
@@ -8,11 +8,15 @@ const Licenses = require('../services/licenses');
 const licenseData = require('../config/licenses/licenses');
 const portReferences = require('../config/licenses/portReferences');
 
-// NOTE: this is a temporary integration test to easify development
-// We probably do not always want to run this as part of the normal test suite
-// since this is hitting actual Wikipedia and Wikimedia APIs.
-// We could consider running it only on CI or introduce a JS-equivalent to VCR
 describe('attribution routes', () => {
+  beforeAll(() => {
+    startRecording('routes/attribution');
+  });
+
+  afterAll(async () => {
+    await stopRecording();
+  });
+
   let context;
 
   const client = new Client();

--- a/routes/fileinfo.integration.test.js
+++ b/routes/fileinfo.integration.test.js
@@ -13,6 +13,13 @@ const portReferences = require('../config/licenses/portReferences');
 // since this is hitting actual Wikipedia and Wikimedia APIs.
 // We could consider running it only on CI or introduce a JS-equivalent to VCR
 describe('fileinfo routes', () => {
+  beforeAll(() => {
+    startRecording('routes/fileinfo');
+  });
+
+  afterAll(async () => {
+    await stopRecording();
+  });
   let context;
 
   const client = new Client();

--- a/services/fileData.integration.test.js
+++ b/services/fileData.integration.test.js
@@ -5,6 +5,14 @@ describe('FileData', () => {
   const client = new Client();
   const fileData = new FileData({ client });
 
+  beforeAll(() => {
+    startRecording('services/fileData.getFileData()');
+  });
+
+  afterAll(async () => {
+    await stopRecording();
+  });
+
   // We got a list of example url that we need to understand and match.
   // This spec calls all these examples and expects they work against a known
   // good state (snapshop).

--- a/services/files.integration.test.js
+++ b/services/files.integration.test.js
@@ -1,12 +1,16 @@
-const Files = require('./files');
 const Client = require('./util/client');
-
+const Files = require('./files');
 const expectedFiles = require('./__fixtures__/expectedFiles');
 
-// NOTE: this is a tmp integration test to easify development
-// we probably do not want to run this by default in the future
-// (only on CI maybe)
 describe('getPageImages()', () => {
+  beforeAll(() => {
+    startRecording('services/files.getPageImages()');
+  });
+
+  afterAll(async () => {
+    await stopRecording();
+  });
+
   const client = new Client();
   const service = new Files({ client });
   const urls = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,84 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@pollyjs/adapter-node-http@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@pollyjs/adapter-node-http/-/adapter-node-http-1.4.2.tgz#f1a12f32e8c8f270a636089a7a56421ab5b4b848"
+  integrity sha512-7bGiqknxcu/5udX6R8MouAA6xLPKRc2NcjivNGdcNlVC3C2iPnwPPkt3fplflh8cW83t9HsWYffqFKpeepctmg==
+  dependencies:
+    "@pollyjs/adapter" "^1.4.1"
+    "@pollyjs/utils" "^1.4.1"
+    lodash-es "^4.17.11"
+    semver "^5.6.0"
+
+"@pollyjs/adapter@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@pollyjs/adapter/-/adapter-1.4.1.tgz#4bf58f5127620f004edfcb7f27b572ba0699aaee"
+  integrity sha512-1CFoFkoFhP/DLhCIbTLpyIKr1jlzHWBTzL2WerE1loWLrCvnI+rw7YYfz2wJxEH9fuF25QRg5P3L2Yrvw5l3ig==
+  dependencies:
+    "@pollyjs/utils" "^1.4.1"
+
+"@pollyjs/core@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@pollyjs/core/-/core-1.4.2.tgz#ef6cc8d55bf8c0c3972bf4ec4ce4567f5b8230a4"
+  integrity sha512-2GCTpVMsObC+D7LvFX88mNMe+bfqNqfab35/lUrpsA6Sg9pthpwaxdIDFDujzfN6Dukuw8JCbY4sY85eJhsvWA==
+  dependencies:
+    "@pollyjs/utils" "^1.4.1"
+    "@sindresorhus/fnv1a" "^1.0.0"
+    blueimp-md5 "^2.10.0"
+    fast-json-stable-stringify "^2.0.0"
+    is-absolute-url "^2.1.0"
+    lodash-es "^4.17.11"
+    route-recognizer "^0.3.4"
+    slugify "^1.3.3"
+
+"@pollyjs/node-server@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@pollyjs/node-server/-/node-server-1.4.1.tgz#75c79bda3d37ff510d2e447dd2ef0f9fa25ffcd0"
+  integrity sha512-AeSjVzJshE6tQlH9DMfV3m4YQOs8whTTjLIQXlLUktSiZLqPdhYDK6I3nerMyOc1jkk80U8f61DhyqrGAG4fvQ==
+  dependencies:
+    "@pollyjs/utils" "^1.4.1"
+    body-parser "^1.18.3"
+    cors "^2.8.5"
+    express "^4.16.4"
+    fs-extra "^5.0.0"
+    http-graceful-shutdown "^2.1.3"
+    morgan "^1.9.1"
+    nocache "^2.0.0"
+
+"@pollyjs/persister-fs@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@pollyjs/persister-fs/-/persister-fs-1.4.2.tgz#cd9894b12d53c2ea5a332e913440eba4ef0398aa"
+  integrity sha512-d/BjngQvWTwMy/DjjUNjm0KQ62p+GavX/Y6e/HmdrdWWSx5G1JhuZ9jcxYfngk3P7y/mwQBw0C5ELnpbsVoAbg==
+  dependencies:
+    "@pollyjs/node-server" "^1.4.1"
+    "@pollyjs/persister" "^1.4.1"
+
+"@pollyjs/persister@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@pollyjs/persister/-/persister-1.4.1.tgz#12de9b582d0ba2154b0b293a0155ac50213a5fe3"
+  integrity sha512-jAeC9D6lrCaq3iKzQTg4gW/1XK9LeZJdzcltCK8jNcqtGEhjGddm5M+DDnTwuKWREXZvtUWBTEcpNvn7WbHbag==
+  dependencies:
+    "@pollyjs/utils" "^1.4.1"
+    bowser "^1.9.3"
+    fast-json-stable-stringify "^2.0.0"
+    lodash-es "^4.17.11"
+    set-cookie-parser "^2.2.1"
+    utf8-byte-length "^1.0.4"
+
+"@pollyjs/utils@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@pollyjs/utils/-/utils-1.4.1.tgz#2cee4980ca9f27427cd62833e916ae28660e6652"
+  integrity sha512-UVIgsj50LBdWZfcUY+Yh0NU9sciLtUW75kqqgnPCagUYnYpsENiih1+C83zs4IcPR7kbuBht8z2EMxeD1tf+qg==
+  dependencies:
+    qs "^6.6.0"
+    url-parse "^1.4.4"
+
+"@sindresorhus/fnv1a@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/fnv1a/-/fnv1a-1.0.0.tgz#d419dd111b4d7fc3b87f97d86849bc23316149de"
+  integrity sha512-n+7NAD9vCDb2PaCRFIGrT2UF8WPIfMgGvCiVsYKY1/eBTrZU80N9erKhX9UTdxyvWhNuxQxwZGzdOIOlt8WqsA==
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -35,6 +113,14 @@ accept@3.x.x:
   dependencies:
     boom "7.x.x"
     hoek "6.x.x"
+
+accepts@~1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
+  integrity sha1-63d99gEXI6OxTopywIBcjoZ0a9I=
+  dependencies:
+    mime-types "~2.1.18"
+    negotiator "0.6.1"
 
 acorn-globals@^4.1.0, acorn-globals@^4.3.0:
   version "4.3.0"
@@ -193,6 +279,11 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
+
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -467,6 +558,13 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+basic-auth@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -492,6 +590,27 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+blueimp-md5@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.10.0.tgz#02f0843921f90dca14f5b8920a38593201d6964d"
+  integrity sha512-EkNUOi7tpV68TqjpiUz9D9NcT8um2+qtgntmMbi5UKssVX2m/2PLqotcric0RE63pB3HPN/fjf3cKHN2ufGSUQ==
+
+body-parser@1.18.3, body-parser@^1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
+  integrity sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "~1.6.3"
+    iconv-lite "0.4.23"
+    on-finished "~2.3.0"
+    qs "6.5.2"
+    raw-body "2.3.3"
+    type-is "~1.6.16"
+
 boom@7.x.x, boom@^7.2.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/boom/-/boom-7.3.0.tgz#733a6d956d33b0b1999da3fe6c12996950d017b9"
@@ -506,6 +625,11 @@ bounce@1.x.x:
   dependencies:
     boom "7.x.x"
     hoek "6.x.x"
+
+bowser@^1.9.3:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
+  integrity sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -623,6 +747,11 @@ bunyan@^1.8.12:
     moment "^2.10.6"
     mv "~2"
     safe-json-stringify "~1"
+
+bytes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+  integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -906,6 +1035,16 @@ contains-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+  integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
+
+content-type@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+
 content@4.x.x:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/content/-/content-4.0.6.tgz#76ffd96c5cbccf64fe3923cbb9c48b8bc04b273e"
@@ -919,6 +1058,16 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -934,6 +1083,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 create-error-class@^3.0.0:
   version "3.0.2"
@@ -1149,6 +1306,16 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -1235,6 +1402,16 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -1280,6 +1457,11 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
+
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1467,6 +1649,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
 exec-sh@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
@@ -1530,6 +1717,42 @@ expect@^23.6.0:
     jest-matcher-utils "^23.6.0"
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
+
+express@^4.16.4:
+  version "4.16.4"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
+  integrity sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==
+  dependencies:
+    accepts "~1.3.5"
+    array-flatten "1.1.1"
+    body-parser "1.18.3"
+    content-disposition "0.5.2"
+    content-type "~1.0.4"
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.1.1"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.4"
+    qs "6.5.2"
+    range-parser "~1.2.0"
+    safe-buffer "5.1.2"
+    send "0.16.2"
+    serve-static "1.13.2"
+    setprototypeof "1.1.0"
+    statuses "~1.4.0"
+    type-is "~1.6.16"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1711,6 +1934,19 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+finalhandler@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
+  integrity sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    statuses "~1.4.0"
+    unpipe "~1.0.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -1769,6 +2005,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+forwarded@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
+  integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -1776,10 +2017,24 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fresh@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  integrity sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -1980,7 +2235,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -2169,6 +2424,23 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
+http-graceful-shutdown@^2.1.3:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/http-graceful-shutdown/-/http-graceful-shutdown-2.2.2.tgz#5fe4efc886d849ccef3896287e1d0815b4f1806e"
+  integrity sha512-ZDsNK0OLD05E7XLuvchzdVDyvWy/ucTm9PTPAxZh+HZ+QFXMA/kw+vjZ/HrTMG6CzmnReDIgLwVMxGn6+iZ9qw==
+  dependencies:
+    debug "^4.1.0"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -2185,6 +2457,13 @@ https-proxy-agent@^2.2.1:
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
+
+iconv-lite@0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
@@ -2241,7 +2520,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -2282,6 +2561,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+ipaddr.js@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
+  integrity sha1-6qM9bd16zo9/b+DJygRA5wZzix4=
+
 iron@5.x.x:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/iron/-/iron-5.0.6.tgz#7121d4a6e3ac2f65e4d02971646fea1995434744"
@@ -2291,6 +2575,11 @@ iron@5.x.x:
     boom "7.x.x"
     cryptiles "4.x.x"
     hoek "6.x.x"
+
+is-absolute-url@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
+  integrity sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -3146,6 +3435,13 @@ json5@^0.5.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -3246,6 +3542,11 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
+  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -3312,12 +3613,22 @@ math-random@^1.0.1:
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
+
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -3330,6 +3641,11 @@ merge@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
+
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
 micromatch@^2.3.11:
   version "2.3.11"
@@ -3374,12 +3690,17 @@ mime-db@1.x.x, mime-db@~1.37.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
   integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
 
-mime-types@^2.1.12, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.21"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
   integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
   dependencies:
     mime-db "~1.37.0"
+
+mime@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+  integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
 mime@^2.0.3, mime@^2.3.1:
   version "2.4.0"
@@ -3455,6 +3776,17 @@ moment@^2.10.6:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"
   integrity sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==
+
+morgan@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
+  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
+  dependencies:
+    basic-auth "~2.0.0"
+    debug "2.6.9"
+    depd "~1.1.2"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
 
 ms@2.0.0:
   version "2.0.0"
@@ -3552,6 +3884,11 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
+negotiator@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+  integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -3564,6 +3901,11 @@ nigel@3.x.x:
   dependencies:
     hoek "6.x.x"
     vise "3.x.x"
+
+nocache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.0.0.tgz#202b48021a0c4cbde2df80de15a17443c8b43980"
+  integrity sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA=
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3689,7 +4031,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -3757,6 +4099,18 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+  dependencies:
+    ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
+  integrity sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -3894,6 +4248,11 @@ parse5@5.1.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
+parseurl@~1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
+  integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -3935,6 +4294,11 @@ path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -4090,6 +4454,14 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
+proxy-addr@~2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
+  integrity sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==
+  dependencies:
+    forwarded "~0.1.2"
+    ipaddr.js "1.8.0"
+
 proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
@@ -4151,10 +4523,20 @@ puppeteer-core@^1.9.0:
     rimraf "^2.6.1"
     ws "^6.1.0"
 
-qs@~6.5.2:
+qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+qs@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
+  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
+
+querystringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
+  integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
 
 randomatic@^3.0.0:
   version "3.1.1"
@@ -4164,6 +4546,21 @@ randomatic@^3.0.0:
     is-number "^4.0.0"
     kind-of "^6.0.0"
     math-random "^1.0.1"
+
+range-parser@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+  integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
+
+raw-body@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
+  integrity sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.3"
+    iconv-lite "0.4.23"
+    unpipe "1.0.0"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
@@ -4365,6 +4762,11 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -4426,6 +4828,11 @@ rimraf@~2.4.0:
   dependencies:
     glob "^6.0.1"
 
+route-recognizer@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
+  integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
+
 rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
@@ -4445,7 +4852,7 @@ rxjs@^6.1.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -4509,15 +4916,49 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+send@0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
+  integrity sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.6.2"
+    mime "1.4.1"
+    ms "2.0.0"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.4.0"
+
+serve-static@1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1"
+  integrity sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.2"
+    send "0.16.2"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.2.1.tgz#eae9e36c48667c9b385246ab6f450aade889aaf4"
+  integrity sha1-6unjbEhmfJs4Ukarb0UKreiJqvQ=
 
 set-value@^0.4.3:
   version "0.4.3"
@@ -4538,6 +4979,11 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
+
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -4587,6 +5033,11 @@ slice-ansi@2.0.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+slugify@^1.3.3:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.4.tgz#78d2792d7222b55cd9fc81fa018df99af779efeb"
+  integrity sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4744,6 +5195,16 @@ static-extend@^0.1.1:
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
+
+"statuses@>= 1.4.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+statuses@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+  integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
 stealthy-require@^1.1.0:
   version "1.1.1"
@@ -5064,6 +5525,14 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-is@~1.6.16:
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
+  integrity sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.18"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -5108,6 +5577,16 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+unpipe@1.0.0, unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -5162,10 +5641,23 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
+url-parse@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
+  integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==
+  dependencies:
+    querystringify "^2.0.0"
+    requires-port "^1.0.0"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8-byte-length@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -5180,6 +5672,11 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
 uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -5192,6 +5689,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+vary@^1, vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Introducing a setup which allows us to use pollyjs to record and replay http requests. This speeds up the tests from >30 seconds to 3 seconds and makes them more reliable (in case someone edits one of our example articles on the actual wikipedia).