### PR TITLE
remove required for author_html/attribution_html in fileinfo response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -45,20 +45,18 @@ definitions:
   InternalServerError:
     description: Internal Server Error
     properties: {}
-  LicenseAuthor_htmlAttribution_htmlMedia_typeModel:
+  LicenseAuthorHtmlAttributionHtmlMediaTypeModel:
     properties:
-      attribution_html:
+      attributionHtml:
         type: string
-      author_html:
+      authorHtml:
         type: string
       license:
         $ref: '#/definitions/CodeNameUrlGroupsModel'
-      media_type:
+      mediaType:
         type: string
     required:
-      - author_html
-      - attribution_html
-      - media_type
+      - mediaType
   RawUrlWidthHeightModel:
     properties:
       height:
@@ -229,7 +227,7 @@ paths:
         default:
           description: ''
           schema:
-            $ref: '#/definitions/LicenseAuthor_htmlAttribution_htmlMedia_typeModel'
+            $ref: '#/definitions/LicenseAuthorHtmlAttributionHtmlMediaTypeModel'
       summary: Image license
       tags:
         - fileinfo

--- a/routes/__snapshots__/fileinfo.test.js.snap
+++ b/routes/__snapshots__/fileinfo.test.js.snap
@@ -34,8 +34,8 @@ Object {
 
 exports[`fileinfo routes GET /fileinfo returns the license of a file 1`] = `
 Object {
-  "attribution_html": "Photograph by <a href=\\"//commons.wikimedia.org/wiki/User:Rama\\" title=\\"User:Rama\\">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr",
-  "author_html": "<a href=\\"//commons.wikimedia.org/wiki/User:Rama\\" title=\\"User:Rama\\">Rama</a> &amp; Musée Bolo",
+  "attributionHtml": "Photograph by <a href=\\"//commons.wikimedia.org/wiki/User:Rama\\" title=\\"User:Rama\\">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr",
+  "authorHtml": "<a href=\\"//commons.wikimedia.org/wiki/User:Rama\\" title=\\"User:Rama\\">Rama</a> &amp; Musée Bolo",
   "license": Object {
     "code": "cc-by-sa-4.0",
     "groups": Array [
@@ -45,6 +45,6 @@ Object {
     "name": "CC BY-SA 4.0",
     "url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode",
   },
-  "media_type": "BITMAP",
+  "mediaType": "BITMAP",
 }
 `;

--- a/routes/fileinfo.integration.test.js
+++ b/routes/fileinfo.integration.test.js
@@ -57,11 +57,11 @@ describe('fileinfo routes', () => {
           url: 'https://creativecommons.org/licenses/by-sa/2.0/fr/deed.en',
           groups: ['cc', 'cc2', 'ported', 'knownPorted'],
         },
-        author_html:
+        authorHtml:
           '<a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a> &amp; Musée Bolo',
-        attribution_html:
+        attributionHtml:
           'Photograph by <a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr',
-        media_type: 'BITMAP',
+        mediaType: 'BITMAP',
       });
     });
   });

--- a/routes/fileinfo.js
+++ b/routes/fileinfo.js
@@ -17,9 +17,9 @@ const responseSchema = Joi.object({
       .required()
       .items(Joi.string()),
   }),
-  author_html: Joi.string(),
-  attribution_html: Joi.string(),
-  media_type: Joi.string().required(),
+  authorHtml: Joi.string(),
+  attributionHtml: Joi.string(),
+  mediaType: Joi.string().required(),
 });
 
 function handleError(h, { message }) {

--- a/routes/fileinfo.js
+++ b/routes/fileinfo.js
@@ -17,8 +17,8 @@ const responseSchema = Joi.object({
       .required()
       .items(Joi.string()),
   }),
-  author_html: Joi.string().required(),
-  attribution_html: Joi.string().required(),
+  author_html: Joi.string(),
+  attribution_html: Joi.string(),
   media_type: Joi.string().required(),
 });
 

--- a/services/util/serializers.js
+++ b/services/util/serializers.js
@@ -16,9 +16,9 @@ function attribution(attributionObject) {
 function fileinfo({ artistHtml, attributionHtml, mediaType }, licenseParam) {
   return {
     license: license(licenseParam),
-    author_html: artistHtml,
-    attribution_html: attributionHtml,
-    media_type: mediaType,
+    authorHtml: artistHtml,
+    attributionHtml,
+    mediaType,
   };
 }
 

--- a/services/util/serializers.test.js
+++ b/services/util/serializers.test.js
@@ -82,11 +82,11 @@ describe('fileinfo()', () => {
         name: 'CC BY-SA 3.0',
         url: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
       },
-      attribution_html:
+      attributionHtml:
         'Photograph by <a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr',
-      author_html:
+      authorHtml:
         '<a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a> &amp; Musée Bolo',
-      media_type: 'BITMAP',
+      mediaType: 'BITMAP',
     });
   });
 
@@ -99,9 +99,9 @@ describe('fileinfo()', () => {
         name: 'CC BY-SA 3.0',
         url: 'https://creativecommons.org/licenses/by-sa/3.0/legalcode',
       },
-      attribution_html: undefined,
-      author_html: undefined,
-      media_type: undefined,
+      attributionHtml: undefined,
+      authorHtml: undefined,
+      mediaType: undefined,
     });
   });
 
@@ -114,11 +114,11 @@ describe('fileinfo()', () => {
         name: undefined,
         url: undefined,
       },
-      attribution_html:
+      attributionHtml:
         'Photograph by <a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a>, Wikimedia Commons, Cc-by-sa-2.0-fr',
-      author_html:
+      authorHtml:
         '<a href="//commons.wikimedia.org/wiki/User:Rama" title="User:Rama">Rama</a> &amp; Musée Bolo',
-      media_type: 'BITMAP',
+      mediaType: 'BITMAP',
     });
   });
 });


### PR DESCRIPTION
This includes two changes:
* remove required for author_html/attribution_html in fileinfo response
* camelize attributes in response of /fileinfo endpoint