### PR TITLE
Allow configuring URL base path in swagger API docs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -7,6 +7,9 @@ SECRET=shhhhhh
 # Service configurations
 SERVICES={}
 
+# Optional base path to prepend /docs URL of swagger API docs
+#DOCS_BASE_PATH=/api
+
 # Matomo config
 MATOMO_URL=http://matomo/path/matomo.php
 MATOMO_SITE_ID=1

--- a/config/swagger.js
+++ b/config/swagger.js
@@ -25,4 +25,8 @@ const config = {
   auth: false,
 };
 
+if (process.env.DOCS_BASE_PATH) {
+  config.basePath = process.env.DOCS_BASE_PATH;
+}
+
 module.exports = config;

--- a/server.js
+++ b/server.js
@@ -39,16 +39,21 @@ async function init(environment) {
     ]);
   }
 
+  const swaggerUiOptions = {
+    title: 'Lizenzgenerator API',
+    path: '/docs',
+  };
+  if (swagger.basePath) {
+    swaggerUiOptions.basePath = swagger.basePath;
+  }
+
   // Register router & swagger plugins.
   await server.register([
     Inert,
     Vision,
     {
       plugin: HapiSwaggerUi,
-      options: {
-        title: 'Lizenzgenerator API',
-        path: '/docs',
-      },
+      options: swaggerUiOptions,
     },
     {
       plugin: HapiRouter,


### PR DESCRIPTION
e.g. to generate right base path in openapi.yml, and also
use right path to load resources (CSS, JS files) in the
generated HTML docs.